### PR TITLE
android: only change capture format for screen if dimen actually changed

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/AbstractVideoCaptureController.java
@@ -3,8 +3,8 @@ package com.oney.WebRTCModule;
 import org.webrtc.VideoCapturer;
 
 public abstract class AbstractVideoCaptureController {
-    private final int width;
-    private final int height;
+    protected int width;
+    protected int height;
     private final int fps;
 
     /**

--- a/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
+++ b/android/src/main/java/com/oney/WebRTCModule/ScreenCaptureController.java
@@ -41,17 +41,21 @@ public class ScreenCaptureController extends AbstractVideoCaptureController {
                 DisplayMetrics displayMetrics = DisplayUtils.getDisplayMetrics((Activity) context);
                 final int width = displayMetrics.widthPixels;
                 final int height = displayMetrics.heightPixels;
+                if (width != ScreenCaptureController.this.width || height != ScreenCaptureController.this.height) {
+                    ScreenCaptureController.this.width = width;
+                    ScreenCaptureController.this.height = height;
 
-                // Pivot to the executor thread because videoCapturer.changeCaptureFormat runs in the main
-                // thread and may deadlock.
-                ThreadUtils.runOnExecutor(() -> {
-                    try {
-                        videoCapturer.changeCaptureFormat(width, height, DEFAULT_FPS);
-                    } catch (Exception ex) {
-                        // We ignore exceptions here. The video capturer runs on its own
-                        // thread and we cannot synchronize with it.
-                    }
-                });
+                    // Pivot to the executor thread because videoCapturer.changeCaptureFormat runs in the main
+                    // thread and may deadlock.
+                    ThreadUtils.runOnExecutor(() -> {
+                        try {
+                            videoCapturer.changeCaptureFormat(width, height, DEFAULT_FPS);
+                        } catch (Exception ex) {
+                            // We ignore exceptions here. The video capturer runs on its own
+                            // thread and we cannot synchronize with it.
+                        }
+                    });
+                }
             }
         };
 


### PR DESCRIPTION
On WebRTC m114, change capture format for screencapture causes a teardown and rebuild of the virtual display and should only be called when absolutely needed. By M118, the change capture format is robust against calls with the same dimens.