### PR TITLE
fix: Handle invalidate for react-native 0.74+

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -117,6 +117,11 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     }
 
     @Override
+    public void invalidate() {
+        onCatalystInstanceDestroy();
+    }
+
+    @Override
     public void onCatalystInstanceDestroy() {
         if (mAudioDeviceModule != null) {
             mAudioDeviceModule.release();

--- a/examples/GumTestApp/package.json
+++ b/examples/GumTestApp/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.71.4",
-    "react-native-webrtc": "*"
+    "@livekit/react-native-webrtc": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
React-Native no longer calls onCatalystInstanceDestroy in 0.74+.