### PR TITLE
fix: fix event-target-shim throwing error in RTCFrameCrypto

### DIFF
--- a/src/RTCFrameCryptor.ts
+++ b/src/RTCFrameCryptor.ts
@@ -1,4 +1,4 @@
-import { Event, EventTarget, defineEventAttribute } from 'event-target-shim';
+import { Event, EventTarget, defineEventAttribute } from 'event-target-shim/index';
 import { NativeModules } from 'react-native';
 
 import { addListener, removeListener } from './EventEmitter';


### PR DESCRIPTION
Fixes https://github.com/livekit/client-sdk-react-native/issues/186