### PR TITLE
pc: don't throw when applyConstraints on audio tracks

### DIFF
--- a/src/MediaStreamTrack.ts
+++ b/src/MediaStreamTrack.ts
@@ -180,6 +180,7 @@ export default class MediaStreamTrack extends EventTarget<MediaStreamTrackEventM
     async applyConstraints(constraints?: MediaTrackConstraints): Promise<void> {
         if (this.kind !== 'video') {
             log.info(`Only implemented for video tracks, ignoring applyConstraints for ${this.id}`);
+
             return;
         }
 


### PR DESCRIPTION
`livekit-client` changed behavior to grab the user media and then apply constraints separately. While we still don't support audio track constraints, we're going to intentionally let it pass silently, since the general web behavior wouldn't throw an error here.

This intentionally departs from the original `react-native-webrtc` behavior for LiveKit purposes only.