### PR TITLE
[WIP] Add configurable audio device ID for WebRTC on Android

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
+++ b/android/src/main/java/com/oney/WebRTCModule/GetUserMediaImpl.java
@@ -88,6 +88,10 @@ class GetUserMediaImpl {
     private AudioTrack createAudioTrack(ReadableMap constraints) {
         ReadableMap audioConstraintsMap = constraints.getMap("audio");
 
+        Log.d(TAG, "==========================================");
+        Log.d(TAG, "JONATHAN'S FORK: USING CUSTOM AUDIO DEVICE CODE");
+        Log.d(TAG, "==========================================");
+
         Log.d(TAG, "getUserMedia(audio): " + audioConstraintsMap);
 
         // Check if a specific audio device ID was requested

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1,5 +1,12 @@
 package com.oney.WebRTCModule;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.os.Build;
 import android.util.Log;
 import android.util.Pair;
 import android.util.SparseArray;
@@ -63,6 +70,9 @@ import java.util.concurrent.ExecutionException;
 @ReactModule(name = "WebRTCModule")
 public class WebRTCModule extends ReactContextBaseJavaModule {
     static final String TAG = WebRTCModule.class.getCanonicalName();
+
+    // Define fork version constant - increment this when making changes to the fork
+    public static final String FORK_VERSION = "fork-version-0";
 
     PeerConnectionFactory mFactory;
     VideoEncoderFactory mVideoEncoderFactory;
@@ -1573,5 +1583,15 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     public void getDefaultAudioDeviceId(Promise promise) {
         String deviceId = WebRTCModuleOptions.getInstance().defaultAudioDeviceId;
         promise.resolve(deviceId);
+    }
+
+    /**
+     * Get the version of this custom fork
+     *
+     * @param promise Promise to resolve with the fork version
+     */
+    @ReactMethod
+    public void getForkVersion(Promise promise) {
+        promise.resolve(FORK_VERSION);
     }
 }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1544,4 +1544,34 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     public void removeListeners(Integer count) {
         // Keep: Required for RN built in Event Emitter Calls.
     }
+
+    /**
+     * Set the default audio device ID to use when no specific device is requested.
+     * This allows applications to control which audio device is used by default.
+     *
+     * @param deviceId The device ID to use as default (e.g., "audio-1", "expo-av-audio", etc.)
+     */
+    @ReactMethod
+    public void setDefaultAudioDeviceId(String deviceId) {
+        if (deviceId != null && !deviceId.isEmpty()) {
+            Log.d(TAG, "Setting default audio device ID to: " + deviceId);
+            WebRTCModuleOptions.getInstance().defaultAudioDeviceId = deviceId;
+            
+            // Update current instance
+            if (getUserMediaImpl != null) {
+                getUserMediaImpl.setAudioDeviceId(deviceId);
+            }
+        }
+    }
+
+    /**
+     * Get the current default audio device ID.
+     *
+     * @param promise Promise to resolve with the current default audio device ID
+     */
+    @ReactMethod
+    public void getDefaultAudioDeviceId(Promise promise) {
+        String deviceId = WebRTCModuleOptions.getInstance().defaultAudioDeviceId;
+        promise.resolve(deviceId);
+    }
 }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -72,7 +72,7 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     static final String TAG = WebRTCModule.class.getCanonicalName();
 
     // Define fork version constant - increment this when making changes to the fork
-    public static final String FORK_VERSION = "fork-version-0";
+    public static final String FORK_VERSION = "fork-version-1";
 
     PeerConnectionFactory mFactory;
     VideoEncoderFactory mVideoEncoderFactory;

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModuleOptions.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModuleOptions.java
@@ -17,6 +17,9 @@ public class WebRTCModuleOptions {
     public AudioDeviceModule audioDeviceModule;
     public Callable<AudioProcessingFactory> audioProcessingFactoryFactory;
 
+    // Default audio device identifier used when no specific device is requested
+    public String defaultAudioDeviceId = "audio-1";
+
     public Loggable injectableLogger;
     public Logging.Severity loggingSeverity;
     public String fieldTrials;

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -13,7 +13,7 @@
 #import <WebRTC/RTCSSLAdapter.h>
 
 // Define fork version constant - increment this when making changes to the fork
-static NSString * const FORK_VERSION = @"fork-version-0";
+static NSString * const FORK_VERSION = @"fork-version-1";
 
 @interface WebRTCModule ()
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -10,6 +10,10 @@
 #import "WebRTCModule+RTCPeerConnection.h"
 #import "WebRTCModule.h"
 #import "WebRTCModuleOptions.h"
+#import <WebRTC/RTCSSLAdapter.h>
+
+// Define fork version constant - increment this when making changes to the fork
+static NSString * const FORK_VERSION = @"fork-version-0";
 
 @interface WebRTCModule ()
 @end
@@ -139,6 +143,23 @@ RCT_EXPORT_MODULE();
         kEventPeerConnectionOnTrack,
         kEventFrameCryptionStateChanged
     ];
+}
+
+/**
+ * Get the default audio device ID
+ */
+RCT_EXPORT_METHOD(getDefaultAudioDeviceId:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    NSString *deviceId = [WebRTCModuleOptions sharedInstance].defaultAudioDeviceId ?: @"";
+    resolve(deviceId);
+}
+
+/**
+ * Get the version of this custom fork
+ */
+RCT_EXPORT_METHOD(getForkVersion:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    resolve(FORK_VERSION);
 }
 
 @end

--- a/src/AudioDeviceModule.ts
+++ b/src/AudioDeviceModule.ts
@@ -1,0 +1,25 @@
+import { NativeModules } from 'react-native'
+const { WebRTCModule } = NativeModules
+
+/**
+ * Set the default audio device ID to use when no specific device is requested.
+ * This allows applications to control which audio device is used by default.
+ *
+ * @param deviceId - The device ID to use as default (e.g., "audio-1", "expo-av-audio", etc.)
+ */
+export function setDefaultAudioDeviceId(deviceId: string): void {
+  if (typeof deviceId !== 'string' || !deviceId.trim()) {
+    throw new TypeError('deviceId must be a non-empty string')
+  }
+
+  WebRTCModule.setDefaultAudioDeviceId(deviceId)
+}
+
+/**
+ * Get the current default audio device ID.
+ *
+ * @returns A promise that resolves to the current default audio device ID
+ */
+export function getDefaultAudioDeviceId(): Promise<string> {
+  return WebRTCModule.getDefaultAudioDeviceId()
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,96 +1,115 @@
-import { NativeModules, Platform } from 'react-native';
-const { WebRTCModule } = NativeModules;
+import { NativeModules, Platform } from 'react-native'
+const { WebRTCModule } = NativeModules
 
 if (WebRTCModule === null) {
-    throw new Error(`WebRTC native module not found.\n${Platform.OS === 'ios' ?
-        'Try executing the "pod install" command inside your projects ios folder.' :
-        'Try executing the "npm install" command inside your projects folder.'
-    }`);
+  throw new Error(
+    `WebRTC native module not found.\n${
+      Platform.OS === 'ios'
+        ? 'Try executing the "pod install" command inside your projects ios folder.'
+        : 'Try executing the "npm install" command inside your projects folder.'
+    }`,
+  )
 }
 
-import { setupNativeEvents } from './EventEmitter';
-import Logger from './Logger';
-import mediaDevices from './MediaDevices';
-import MediaStream from './MediaStream';
-import MediaStreamTrack, { type MediaTrackSettings } from './MediaStreamTrack';
-import MediaStreamTrackEvent from './MediaStreamTrackEvent';
-import permissions from './Permissions';
-import RTCAudioSession from './RTCAudioSession';
-import RTCErrorEvent from './RTCErrorEvent';
-import RTCFrameCryptor, { RTCFrameCryptorState } from './RTCFrameCryptor';
-import RTCFrameCryptorFactory, { RTCFrameCryptorAlgorithm, RTCKeyProviderOptions } from './RTCFrameCryptorFactory';
-import RTCIceCandidate from './RTCIceCandidate';
-import RTCKeyProvider from './RTCKeyProvider';
-import RTCPIPView, { startIOSPIP, stopIOSPIP } from './RTCPIPView';
-import RTCPeerConnection from './RTCPeerConnection';
-import RTCRtpReceiver from './RTCRtpReceiver';
-import RTCRtpSender from './RTCRtpSender';
-import RTCRtpTransceiver from './RTCRtpTransceiver';
-import RTCSessionDescription from './RTCSessionDescription';
-import RTCView, { type RTCVideoViewProps, type RTCIOSPIPOptions } from './RTCView';
-import ScreenCapturePickerView from './ScreenCapturePickerView';
+import {
+  getDefaultAudioDeviceId,
+  setDefaultAudioDeviceId,
+} from './AudioDeviceModule'
+import { setupNativeEvents } from './EventEmitter'
+import Logger from './Logger'
+import mediaDevices from './MediaDevices'
+import MediaStream from './MediaStream'
+import MediaStreamTrack, { type MediaTrackSettings } from './MediaStreamTrack'
+import MediaStreamTrackEvent from './MediaStreamTrackEvent'
+import permissions from './Permissions'
+import RTCAudioSession from './RTCAudioSession'
+import RTCErrorEvent from './RTCErrorEvent'
+import RTCFrameCryptor, { RTCFrameCryptorState } from './RTCFrameCryptor'
+import RTCFrameCryptorFactory, {
+  RTCFrameCryptorAlgorithm,
+  RTCKeyProviderOptions,
+} from './RTCFrameCryptorFactory'
+import RTCIceCandidate from './RTCIceCandidate'
+import RTCKeyProvider from './RTCKeyProvider'
+import RTCPIPView, { startIOSPIP, stopIOSPIP } from './RTCPIPView'
+import RTCPeerConnection from './RTCPeerConnection'
+import RTCRtpReceiver from './RTCRtpReceiver'
+import RTCRtpSender from './RTCRtpSender'
+import RTCRtpTransceiver from './RTCRtpTransceiver'
+import RTCSessionDescription from './RTCSessionDescription'
+import RTCView, {
+  type RTCIOSPIPOptions,
+  type RTCVideoViewProps,
+} from './RTCView'
+import ScreenCapturePickerView from './ScreenCapturePickerView'
 
-Logger.enable(`${Logger.ROOT_PREFIX}:*`);
+Logger.enable(`${Logger.ROOT_PREFIX}:*`)
 
 // Add listeners for the native events early, since they are added asynchronously.
-setupNativeEvents();
+setupNativeEvents()
 
 export {
-    RTCIceCandidate,
-    RTCPeerConnection,
-    RTCSessionDescription,
-    RTCView,
-    RTCPIPView,
-    ScreenCapturePickerView,
-    RTCRtpTransceiver,
-    RTCRtpReceiver,
-    RTCRtpSender,
-    RTCErrorEvent,
-    RTCAudioSession,
-    RTCFrameCryptor,
-    RTCFrameCryptorAlgorithm,
-    RTCFrameCryptorState,
-    RTCFrameCryptorFactory,
-    RTCKeyProvider,
-    RTCKeyProviderOptions,
-    MediaStream,
-    MediaStreamTrack,
-    type MediaTrackSettings,
-    type RTCVideoViewProps,
-    type RTCIOSPIPOptions,
-    mediaDevices,
-    permissions,
-    registerGlobals,
-    startIOSPIP,
-    stopIOSPIP,
-};
+  // Audio device management
+  getDefaultAudioDeviceId,
+  mediaDevices,
+  MediaStream,
+  MediaStreamTrack,
+  permissions,
+  registerGlobals,
+  RTCAudioSession,
+  RTCErrorEvent,
+  RTCFrameCryptor,
+  RTCFrameCryptorAlgorithm,
+  RTCFrameCryptorFactory,
+  RTCFrameCryptorState,
+  RTCIceCandidate,
+  RTCKeyProvider,
+  RTCKeyProviderOptions,
+  RTCPeerConnection,
+  RTCPIPView,
+  RTCRtpReceiver,
+  RTCRtpSender,
+  RTCRtpTransceiver,
+  RTCSessionDescription,
+  RTCView,
+  ScreenCapturePickerView,
+  setDefaultAudioDeviceId,
+  startIOSPIP,
+  stopIOSPIP,
+  type MediaTrackSettings,
+  type RTCIOSPIPOptions,
+  type RTCVideoViewProps,
+}
 
-declare const global: any;
+declare const global: any
 
 function registerGlobals(): void {
-    // Should not happen. React Native has a global navigator object.
-    if (typeof global.navigator !== 'object') {
-        throw new Error('navigator is not an object');
-    }
+  // Should not happen. React Native has a global navigator object.
+  if (typeof global.navigator !== 'object') {
+    throw new Error('navigator is not an object')
+  }
 
-    if (!global.navigator.mediaDevices) {
-        global.navigator.mediaDevices = {};
-    }
+  if (!global.navigator.mediaDevices) {
+    global.navigator.mediaDevices = {}
+  }
 
-    global.navigator.mediaDevices.getUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
-    global.navigator.mediaDevices.getDisplayMedia = mediaDevices.getDisplayMedia.bind(mediaDevices);
-    global.navigator.mediaDevices.enumerateDevices = mediaDevices.enumerateDevices.bind(mediaDevices);
+  global.navigator.mediaDevices.getUserMedia =
+    mediaDevices.getUserMedia.bind(mediaDevices)
+  global.navigator.mediaDevices.getDisplayMedia =
+    mediaDevices.getDisplayMedia.bind(mediaDevices)
+  global.navigator.mediaDevices.enumerateDevices =
+    mediaDevices.enumerateDevices.bind(mediaDevices)
 
-    global.RTCIceCandidate = RTCIceCandidate;
-    global.RTCPeerConnection = RTCPeerConnection;
-    global.RTCRtpReceiver = RTCRtpReceiver;
-    global.RTCRtpSender = RTCRtpReceiver;
-    global.RTCSessionDescription = RTCSessionDescription;
-    global.MediaStream = MediaStream;
-    global.MediaStreamTrack = MediaStreamTrack;
-    global.MediaStreamTrackEvent = MediaStreamTrackEvent;
-    global.RTCRtpTransceiver = RTCRtpTransceiver;
-    global.RTCRtpReceiver = RTCRtpReceiver;
-    global.RTCRtpSender = RTCRtpSender;
-    global.RTCErrorEvent = RTCErrorEvent;
+  global.RTCIceCandidate = RTCIceCandidate
+  global.RTCPeerConnection = RTCPeerConnection
+  global.RTCRtpReceiver = RTCRtpReceiver
+  global.RTCRtpSender = RTCRtpReceiver
+  global.RTCSessionDescription = RTCSessionDescription
+  global.MediaStream = MediaStream
+  global.MediaStreamTrack = MediaStreamTrack
+  global.MediaStreamTrackEvent = MediaStreamTrackEvent
+  global.RTCRtpTransceiver = RTCRtpTransceiver
+  global.RTCRtpReceiver = RTCRtpReceiver
+  global.RTCRtpSender = RTCRtpSender
+  global.RTCErrorEvent = RTCErrorEvent
 }


### PR DESCRIPTION

## Overview
This PR adds the ability to configure the audio device ID used by WebRTC on Android. Currently, the WebRTC implementation on React Native only reports a single hardcoded "audio-1" device regardless of what physical microphone is connected, making it difficult to work with multiple audio inputs or integrate with other audio libraries like Expo AV.

## Changes
- Added a configurable `defaultAudioDeviceId` field to `WebRTCModuleOptions`
- Modified `GetUserMediaImpl` to use this configurable ID throughout the audio device lifecycle
- Added support for overriding the default via audio constraints in `getUserMedia`
- Added new JavaScript APIs to get and set the default audio device ID
- Updated all related code to use the configurable device ID instead of hardcoded "audio-1"

## JavaScript API
```javascript
// Set the default audio device ID
setDefaultAudioDeviceId('expo-av-audio');

// Get the current default audio device ID
const deviceId = await getDefaultAudioDeviceId();
```

## Use Cases
This PR helps solve several issues:
1. **Integration with other audio libraries**: Allows setting the audio device ID to match what Expo AV or other libraries use
2. **External microphone support**: Makes it easier to handle external microphones that may not be detected correctly with the default ID
3. **Cross-platform consistency**: Better audio device handling across platforms

## Testing
I've tested this with both built-in and external microphones on Android. The configurable ID effectively allows WebRTC to use the same microphone as other audio APIs by setting the appropriate device ID.

## Related Issues
This addresses the common issue where WebRTC and other audio APIs (like Expo AV) can't use the same microphone device on Android. 
