### PR TITLE
ios: pin WebRTC-SDK to 125.6422.07 due to api compatibility

### DIFF
--- a/livekit-react-native-webrtc.podspec
+++ b/livekit-react-native-webrtc.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'WebRTC-SDK', '~>125.6422.07'
+  s.dependency          'WebRTC-SDK', '=125.6422.07'
   
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
Temp fix for #36