### PR TITLE
release 125.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "125.0.10",
+  "version": "125.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@livekit/react-native-webrtc",
-      "version": "125.0.10",
+      "version": "125.0.11",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "125.0.10",
+  "version": "125.0.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/livekit/react-native-webrtc.git"


### PR DESCRIPTION
1a5f3d6 ios: pin WebRTC-SDK to 125.6422.07 due to api compatibility (#37)  ( davidliu 2025-07-08 16:04:05 +0900)