### PR TITLE
release: 144.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "144.1.0-beta.2",
+  "version": "144.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@livekit/react-native-webrtc",
-      "version": "144.1.0-beta.2",
+      "version": "144.1.0",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "144.1.0-beta.2",
+  "version": "144.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/livekit/react-native-webrtc.git"


### PR DESCRIPTION
287fca2 android: bump libwebrtc to 144.7559.05 (#83)  ( davidliu 2026-05-26 23:26:13 +0900) 
bfb1b73 chore(pinact): pin/update GitHub Actions (#85)  ( davidliu 2026-05-26 23:11:16 +0900) 
1e99057 ci: pinact (#84)  ( davidliu 2026-05-26 20:11:48 +0900) 
4880685 release: 144.1.0-beta.2 (#82)  ( davidliu 2026-04-21 17:33:02 +0900) 
2be039f Bump to lib 144.7559.04 (#81)  ( Hiroshi Horie 2026-04-21 16:24:44 +0800) 
c145d88 release: 144.1.0-beta.1 (#79)  ( davidliu 2026-04-06 19:24:57 +0900) 
d3a6f04 android: add registerTrack methods for 3rd party track registration (#78)  ( davidliu 2026-04-06 19:09:30 +0900)