### PR TITLE
fix(ios): skip AudioDeviceModule JS round-trips when no handler is registered

### DIFF
--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.h
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.h
@@ -9,12 +9,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Tracks whether each JS handler is registered. When NO, the observer returns
 // immediately without a JS round trip, avoiding the deadlock window entirely.
-@property(nonatomic, assign) BOOL isEngineCreatedActive;
-@property(nonatomic, assign) BOOL isWillEnableEngineActive;
-@property(nonatomic, assign) BOOL isWillStartEngineActive;
-@property(nonatomic, assign) BOOL isDidStopEngineActive;
-@property(nonatomic, assign) BOOL isDidDisableEngineActive;
-@property(nonatomic, assign) BOOL isWillReleaseEngineActive;
+// Atomic because they are written on the JS thread (handler registration) and
+// read on the native audio thread (delegate callbacks).
+@property(atomic, assign) BOOL isEngineCreatedActive;
+@property(atomic, assign) BOOL isWillEnableEngineActive;
+@property(atomic, assign) BOOL isWillStartEngineActive;
+@property(atomic, assign) BOOL isDidStopEngineActive;
+@property(atomic, assign) BOOL isDidDisableEngineActive;
+@property(atomic, assign) BOOL isWillReleaseEngineActive;
 
 // Methods to receive results from JS. requestId echoes the id sent with the
 // corresponding event so stale responses from timed-out rounds can be dropped.

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.h
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.h
@@ -7,6 +7,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithWebRTCModule:(WebRTCModule *)module;
 
+// Tracks whether each JS handler is registered. When NO, the observer returns
+// immediately without a JS round trip, avoiding the deadlock window entirely.
+@property(nonatomic, assign) BOOL isEngineCreatedActive;
+@property(nonatomic, assign) BOOL isWillEnableEngineActive;
+@property(nonatomic, assign) BOOL isWillStartEngineActive;
+@property(nonatomic, assign) BOOL isDidStopEngineActive;
+@property(nonatomic, assign) BOOL isDidDisableEngineActive;
+@property(nonatomic, assign) BOOL isWillReleaseEngineActive;
+
 // Methods to receive results from JS. requestId echoes the id sent with the
 // corresponding event so stale responses from timed-out rounds can be dropped.
 - (void)resolveEngineCreatedWithRequestId:(NSInteger)requestId result:(NSInteger)result;

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -175,7 +175,9 @@ static os_log_t ADMObserverLog(void) {
                                           }
                                              isActive:isActive];
 
-    RCTLog(@"[AudioDeviceModuleObserver] Engine created - JS returned: %ld", (long)result);
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine created - JS returned: %ld", (long)result);
+    }
     return result;
 }
 
@@ -202,10 +204,12 @@ static os_log_t ADMObserverLog(void) {
                                           }
                                              isActive:isActive];
 
-    RCTLog(@"[AudioDeviceModuleObserver] Engine will enable - JS returned: %ld", (long)result);
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine will enable - JS returned: %ld", (long)result);
 
-    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-    RCTLog(@"[AudioDeviceModuleObserver] Audio session category: %@", audioSession.category);
+        AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+        RCTLog(@"[AudioDeviceModuleObserver] Audio session category: %@", audioSession.category);
+    }
 
     return result;
 }
@@ -233,7 +237,9 @@ static os_log_t ADMObserverLog(void) {
                                           }
                                              isActive:isActive];
 
-    RCTLog(@"[AudioDeviceModuleObserver] Engine will start - JS returned: %ld", (long)result);
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine will start - JS returned: %ld", (long)result);
+    }
     return result;
 }
 
@@ -260,7 +266,9 @@ static os_log_t ADMObserverLog(void) {
                                           }
                                              isActive:isActive];
 
-    RCTLog(@"[AudioDeviceModuleObserver] Engine did stop - JS returned: %ld", (long)result);
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine did stop - JS returned: %ld", (long)result);
+    }
     return result;
 }
 
@@ -287,7 +295,9 @@ static os_log_t ADMObserverLog(void) {
                                           }
                                              isActive:isActive];
 
-    RCTLog(@"[AudioDeviceModuleObserver] Engine did disable - JS returned: %ld", (long)result);
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine did disable - JS returned: %ld", (long)result);
+    }
     return result;
 }
 
@@ -306,7 +316,9 @@ static os_log_t ADMObserverLog(void) {
                                           }
                                              isActive:isActive];
 
-    RCTLog(@"[AudioDeviceModuleObserver] Engine will release - JS returned: %ld", (long)result);
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine will release - JS returned: %ld", (long)result);
+    }
     return result;
 }
 

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -87,11 +87,22 @@ static os_log_t ADMObserverLog(void) {
 // already given up). No legitimate signal for *this* round can exist at drain
 // time because the event has not been sent yet.
 //
-// Returns the JS-provided result on success, or 0 on timeout.
+// If isActive is NO, returns 0 immediately without a JS round trip, avoiding the
+// deadlock window when no handler is registered.
+//
+// Returns the JS-provided result on success, or 0 on timeout or when inactive.
 - (NSInteger)sendEventAndWaitWithName:(NSString *)eventName
                                  body:(NSDictionary *)body
                             semaphore:(dispatch_semaphore_t)semaphore
-                          resultBlock:(NSInteger (^)(void))resultBlock {
+                          resultBlock:(NSInteger (^)(void))resultBlock
+                             isActive:(BOOL)isActive {
+    if (!isActive) {
+        // No handler registered, proceed immediately without JS round trip.
+        // This avoids the deadlock window entirely.
+        os_log(ADMObserverLog(), "Skipping JS round-trip for %{public}@ (no handler registered)", eventName);
+        return 0;
+    }
+
     NSInteger requestId;
     @synchronized(self) {
         requestId = ++self.requestIdSeq;
@@ -139,14 +150,19 @@ static os_log_t ADMObserverLog(void) {
 }
 
 - (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule didCreateEngine:(AVAudioEngine *)engine {
-    RCTLog(@"[AudioDeviceModuleObserver] Engine created - waiting for JS response");
+    BOOL isActive = self.isEngineCreatedActive;
+
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine created - waiting for JS response");
+    }
 
     NSInteger result = [self sendEventAndWaitWithName:kEventAudioDeviceModuleEngineCreated
                                                  body:@{}
                                             semaphore:self.engineCreatedSemaphore
                                           resultBlock:^NSInteger {
                                               return self.engineCreatedResult;
-                                          }];
+                                          }
+                                             isActive:isActive];
 
     RCTLog(@"[AudioDeviceModuleObserver] Engine created - JS returned: %ld", (long)result);
     return result;
@@ -156,9 +172,13 @@ static os_log_t ADMObserverLog(void) {
               willEnableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
-    RCTLog(@"[AudioDeviceModuleObserver] Engine will enable - playout: %d, recording: %d - waiting for JS response",
-           isPlayoutEnabled,
-           isRecordingEnabled);
+    BOOL isActive = self.isWillEnableEngineActive;
+
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine will enable - playout: %d, recording: %d - waiting for JS response",
+               isPlayoutEnabled,
+               isRecordingEnabled);
+    }
 
     NSInteger result = [self sendEventAndWaitWithName:kEventAudioDeviceModuleEngineWillEnable
                                                  body:@{
@@ -168,7 +188,8 @@ static os_log_t ADMObserverLog(void) {
                                             semaphore:self.willEnableEngineSemaphore
                                           resultBlock:^NSInteger {
                                               return self.willEnableEngineResult;
-                                          }];
+                                          }
+                                             isActive:isActive];
 
     RCTLog(@"[AudioDeviceModuleObserver] Engine will enable - JS returned: %ld", (long)result);
 
@@ -182,9 +203,13 @@ static os_log_t ADMObserverLog(void) {
                willStartEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
-    RCTLog(@"[AudioDeviceModuleObserver] Engine will start - playout: %d, recording: %d - waiting for JS response",
-           isPlayoutEnabled,
-           isRecordingEnabled);
+    BOOL isActive = self.isWillStartEngineActive;
+
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine will start - playout: %d, recording: %d - waiting for JS response",
+               isPlayoutEnabled,
+               isRecordingEnabled);
+    }
 
     NSInteger result = [self sendEventAndWaitWithName:kEventAudioDeviceModuleEngineWillStart
                                                  body:@{
@@ -194,7 +219,8 @@ static os_log_t ADMObserverLog(void) {
                                             semaphore:self.willStartEngineSemaphore
                                           resultBlock:^NSInteger {
                                               return self.willStartEngineResult;
-                                          }];
+                                          }
+                                             isActive:isActive];
 
     RCTLog(@"[AudioDeviceModuleObserver] Engine will start - JS returned: %ld", (long)result);
     return result;
@@ -204,9 +230,13 @@ static os_log_t ADMObserverLog(void) {
                  didStopEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
-    RCTLog(@"[AudioDeviceModuleObserver] Engine did stop - playout: %d, recording: %d - waiting for JS response",
-           isPlayoutEnabled,
-           isRecordingEnabled);
+    BOOL isActive = self.isDidStopEngineActive;
+
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine did stop - playout: %d, recording: %d - waiting for JS response",
+               isPlayoutEnabled,
+               isRecordingEnabled);
+    }
 
     NSInteger result = [self sendEventAndWaitWithName:kEventAudioDeviceModuleEngineDidStop
                                                  body:@{
@@ -216,7 +246,8 @@ static os_log_t ADMObserverLog(void) {
                                             semaphore:self.didStopEngineSemaphore
                                           resultBlock:^NSInteger {
                                               return self.didStopEngineResult;
-                                          }];
+                                          }
+                                             isActive:isActive];
 
     RCTLog(@"[AudioDeviceModuleObserver] Engine did stop - JS returned: %ld", (long)result);
     return result;
@@ -226,9 +257,13 @@ static os_log_t ADMObserverLog(void) {
               didDisableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
-    RCTLog(@"[AudioDeviceModuleObserver] Engine did disable - playout: %d, recording: %d - waiting for JS response",
-           isPlayoutEnabled,
-           isRecordingEnabled);
+    BOOL isActive = self.isDidDisableEngineActive;
+
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine did disable - playout: %d, recording: %d - waiting for JS response",
+               isPlayoutEnabled,
+               isRecordingEnabled);
+    }
 
     NSInteger result = [self sendEventAndWaitWithName:kEventAudioDeviceModuleEngineDidDisable
                                                  body:@{
@@ -238,21 +273,27 @@ static os_log_t ADMObserverLog(void) {
                                             semaphore:self.didDisableEngineSemaphore
                                           resultBlock:^NSInteger {
                                               return self.didDisableEngineResult;
-                                          }];
+                                          }
+                                             isActive:isActive];
 
     RCTLog(@"[AudioDeviceModuleObserver] Engine did disable - JS returned: %ld", (long)result);
     return result;
 }
 
 - (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule willReleaseEngine:(AVAudioEngine *)engine {
-    RCTLog(@"[AudioDeviceModuleObserver] Engine will release - waiting for JS response");
+    BOOL isActive = self.isWillReleaseEngineActive;
+
+    if (isActive) {
+        RCTLog(@"[AudioDeviceModuleObserver] Engine will release - waiting for JS response");
+    }
 
     NSInteger result = [self sendEventAndWaitWithName:kEventAudioDeviceModuleEngineWillRelease
                                                  body:@{}
                                             semaphore:self.willReleaseEngineSemaphore
                                           resultBlock:^NSInteger {
                                               return self.willReleaseEngineResult;
-                                          }];
+                                          }
+                                             isActive:isActive];
 
     RCTLog(@"[AudioDeviceModuleObserver] Engine will release - JS returned: %ld", (long)result);
     return result;

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -110,7 +110,7 @@ static os_log_t ADMObserverLog(void) {
     if (!isActive) {
         // No handler registered, proceed immediately without JS round trip.
         // This avoids the deadlock window entirely.
-        os_log(ADMObserverLog(), "Skipping JS round-trip for %{public}@ (no handler registered)", eventName);
+        os_log_debug(ADMObserverLog(), "Skipping JS round-trip for %{public}@ (no handler registered)", eventName);
         return 0;
     }
 

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -69,6 +69,17 @@ static os_log_t ADMObserverLog(void) {
         _didStopEngineSemaphore = dispatch_semaphore_create(0);
         _didDisableEngineSemaphore = dispatch_semaphore_create(0);
         _willReleaseEngineSemaphore = dispatch_semaphore_create(0);
+
+        // Default every hook to active so a delegate callback that fires before JS
+        // has reconciled its handler state (e.g. a recreated observer) still does the
+        // bounded round trip rather than silently skipping a handler's veto. JS
+        // reconciles these to the real handler state in setupListeners().
+        _isEngineCreatedActive = YES;
+        _isWillEnableEngineActive = YES;
+        _isWillStartEngineActive = YES;
+        _isDidStopEngineActive = YES;
+        _isDidDisableEngineActive = YES;
+        _isWillReleaseEngineActive = YES;
     }
     return self;
 }

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.m
@@ -271,4 +271,36 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleResolveWillReleaseEngine
     return nil;
 }
 
+#pragma mark - Handler Active State
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetEngineCreatedActive : (BOOL)isActive) {
+    self.audioDeviceModuleObserver.isEngineCreatedActive = isActive;
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetWillEnableEngineActive : (BOOL)isActive) {
+    self.audioDeviceModuleObserver.isWillEnableEngineActive = isActive;
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetWillStartEngineActive : (BOOL)isActive) {
+    self.audioDeviceModuleObserver.isWillStartEngineActive = isActive;
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetDidStopEngineActive : (BOOL)isActive) {
+    self.audioDeviceModuleObserver.isDidStopEngineActive = isActive;
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetDidDisableEngineActive : (BOOL)isActive) {
+    self.audioDeviceModuleObserver.isDidDisableEngineActive = isActive;
+    return nil;
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetWillReleaseEngineActive : (BOOL)isActive) {
+    self.audioDeviceModuleObserver.isWillReleaseEngineActive = isActive;
+    return nil;
+}
+
 @end

--- a/src/AudioDeviceModuleEvents.ts
+++ b/src/AudioDeviceModuleEvents.ts
@@ -173,6 +173,23 @@ class AudioDeviceModuleEventEmitter {
 
                 WebRTCModule.audioDeviceModuleResolveWillReleaseEngine(requestId, result);
             });
+
+            // Reconcile native active flags with the current handler state. Native
+            // defaults every hook to active, so pushing the real state here makes a
+            // fresh or recreated observer match the handlers registered now instead
+            // of depending on a set/clear transition that may have already happened.
+            const activeFlags: [string, boolean][] = [
+                [ 'audioDeviceModuleSetEngineCreatedActive', this.engineCreatedHandler !== null ],
+                [ 'audioDeviceModuleSetWillEnableEngineActive', this.willEnableEngineHandler !== null ],
+                [ 'audioDeviceModuleSetWillStartEngineActive', this.willStartEngineHandler !== null ],
+                [ 'audioDeviceModuleSetDidStopEngineActive', this.didStopEngineHandler !== null ],
+                [ 'audioDeviceModuleSetDidDisableEngineActive', this.didDisableEngineHandler !== null ],
+                [ 'audioDeviceModuleSetWillReleaseEngineActive', this.willReleaseEngineHandler !== null ],
+            ];
+
+            for (const [ method, isActive ] of activeFlags) {
+                this.pushHandlerActive(method, isActive);
+            }
         }
     }
 

--- a/src/AudioDeviceModuleEvents.ts
+++ b/src/AudioDeviceModuleEvents.ts
@@ -59,8 +59,18 @@ class AudioDeviceModuleEventEmitter {
     private didDisableEngineHandler: AudioEngineEventHandler | null = null;
     private willReleaseEngineHandler: AudioEngineEventNoParamsHandler | null = null;
 
+    private listenersSetUp = false;
+
     public setupListeners() {
         if (Platform.OS !== 'android' && WebRTCModule) {
+            // addListener appends without de-duping, so guard against a second
+            // registerGlobals() double-registering listeners and double-invoking handlers.
+            if (this.listenersSetUp) {
+                return;
+            }
+
+            this.listenersSetUp = true;
+
             // Setup handlers for blocking delegate methods
             addListener(this, 'audioDeviceModuleEngineCreated', async (event: unknown) => {
                 const { requestId } = event as EngineEventPayload;

--- a/src/AudioDeviceModuleEvents.ts
+++ b/src/AudioDeviceModuleEvents.ts
@@ -205,6 +205,17 @@ class AudioDeviceModuleEventEmitter {
     }
 
     /**
+     * Push a handler's active state to native. The native active-flag setters are
+     * iOS/macOS only, so this is gated like setupListeners() to avoid a TypeError
+     * on Android, where these methods do not exist.
+     */
+    private pushHandlerActive(method: string, isActive: boolean) {
+        if (Platform.OS !== 'android' && WebRTCModule) {
+            WebRTCModule[method](isActive);
+        }
+    }
+
+    /**
      * Set handler for engine created delegate - MUST return 0 for success or error code
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
@@ -214,9 +225,8 @@ class AudioDeviceModuleEventEmitter {
         this.engineCreatedHandler = handler;
         const isActive = this.engineCreatedHandler !== null;
 
-        // Notify native about active state change to avoid unnecessary JS round trips
-        if (wasActive !== isActive && WebRTCModule) {
-            WebRTCModule.audioDeviceModuleSetEngineCreatedActive(isActive);
+        if (wasActive !== isActive) {
+            this.pushHandlerActive('audioDeviceModuleSetEngineCreatedActive', isActive);
         }
     }
 
@@ -230,8 +240,8 @@ class AudioDeviceModuleEventEmitter {
         this.willEnableEngineHandler = handler;
         const isActive = this.willEnableEngineHandler !== null;
 
-        if (wasActive !== isActive && WebRTCModule) {
-            WebRTCModule.audioDeviceModuleSetWillEnableEngineActive(isActive);
+        if (wasActive !== isActive) {
+            this.pushHandlerActive('audioDeviceModuleSetWillEnableEngineActive', isActive);
         }
     }
 
@@ -245,8 +255,8 @@ class AudioDeviceModuleEventEmitter {
         this.willStartEngineHandler = handler;
         const isActive = this.willStartEngineHandler !== null;
 
-        if (wasActive !== isActive && WebRTCModule) {
-            WebRTCModule.audioDeviceModuleSetWillStartEngineActive(isActive);
+        if (wasActive !== isActive) {
+            this.pushHandlerActive('audioDeviceModuleSetWillStartEngineActive', isActive);
         }
     }
 
@@ -260,8 +270,8 @@ class AudioDeviceModuleEventEmitter {
         this.didStopEngineHandler = handler;
         const isActive = this.didStopEngineHandler !== null;
 
-        if (wasActive !== isActive && WebRTCModule) {
-            WebRTCModule.audioDeviceModuleSetDidStopEngineActive(isActive);
+        if (wasActive !== isActive) {
+            this.pushHandlerActive('audioDeviceModuleSetDidStopEngineActive', isActive);
         }
     }
 
@@ -275,8 +285,8 @@ class AudioDeviceModuleEventEmitter {
         this.didDisableEngineHandler = handler;
         const isActive = this.didDisableEngineHandler !== null;
 
-        if (wasActive !== isActive && WebRTCModule) {
-            WebRTCModule.audioDeviceModuleSetDidDisableEngineActive(isActive);
+        if (wasActive !== isActive) {
+            this.pushHandlerActive('audioDeviceModuleSetDidDisableEngineActive', isActive);
         }
     }
 
@@ -290,8 +300,8 @@ class AudioDeviceModuleEventEmitter {
         this.willReleaseEngineHandler = handler;
         const isActive = this.willReleaseEngineHandler !== null;
 
-        if (wasActive !== isActive && WebRTCModule) {
-            WebRTCModule.audioDeviceModuleSetWillReleaseEngineActive(isActive);
+        if (wasActive !== isActive) {
+            this.pushHandlerActive('audioDeviceModuleSetWillReleaseEngineActive', isActive);
         }
     }
 }

--- a/src/AudioDeviceModuleEvents.ts
+++ b/src/AudioDeviceModuleEvents.ts
@@ -63,9 +63,13 @@ class AudioDeviceModuleEventEmitter {
 
     public setupListeners() {
         if (Platform.OS !== 'android' && WebRTCModule) {
-            // addListener appends without de-duping, so guard against a second
-            // registerGlobals() double-registering listeners and double-invoking handlers.
+            // Reconcile on every call so a recreated native observer (which defaults
+            // every hook to active) is re-synced to the current handler state even
+            // when JS listeners are already registered. addListener appends without
+            // de-duping, so the registration below must run only once.
             if (this.listenersSetUp) {
+                this.reconcileActiveFlags();
+
                 return;
             }
 
@@ -184,22 +188,7 @@ class AudioDeviceModuleEventEmitter {
                 WebRTCModule.audioDeviceModuleResolveWillReleaseEngine(requestId, result);
             });
 
-            // Reconcile native active flags with the current handler state. Native
-            // defaults every hook to active, so pushing the real state here makes a
-            // fresh or recreated observer match the handlers registered now instead
-            // of depending on a set/clear transition that may have already happened.
-            const activeFlags: [string, boolean][] = [
-                [ 'audioDeviceModuleSetEngineCreatedActive', this.engineCreatedHandler !== null ],
-                [ 'audioDeviceModuleSetWillEnableEngineActive', this.willEnableEngineHandler !== null ],
-                [ 'audioDeviceModuleSetWillStartEngineActive', this.willStartEngineHandler !== null ],
-                [ 'audioDeviceModuleSetDidStopEngineActive', this.didStopEngineHandler !== null ],
-                [ 'audioDeviceModuleSetDidDisableEngineActive', this.didDisableEngineHandler !== null ],
-                [ 'audioDeviceModuleSetWillReleaseEngineActive', this.willReleaseEngineHandler !== null ],
-            ];
-
-            for (const [ method, isActive ] of activeFlags) {
-                this.pushHandlerActive(method, isActive);
-            }
+            this.reconcileActiveFlags();
         }
     }
 
@@ -262,6 +251,27 @@ class AudioDeviceModuleEventEmitter {
 
         if (!isActive && wasActive) {
             this.pushHandlerActive(method, false);
+        }
+    }
+
+    /**
+     * Push the current handler state for every hook to native. Native defaults
+     * each hook to active, so this re-syncs a fresh or recreated observer to the
+     * handlers registered now rather than relying on a set/clear transition that
+     * may have already happened.
+     */
+    private reconcileActiveFlags() {
+        const activeFlags: [string, boolean][] = [
+            [ 'audioDeviceModuleSetEngineCreatedActive', this.engineCreatedHandler !== null ],
+            [ 'audioDeviceModuleSetWillEnableEngineActive', this.willEnableEngineHandler !== null ],
+            [ 'audioDeviceModuleSetWillStartEngineActive', this.willStartEngineHandler !== null ],
+            [ 'audioDeviceModuleSetDidStopEngineActive', this.didStopEngineHandler !== null ],
+            [ 'audioDeviceModuleSetDidDisableEngineActive', this.didDisableEngineHandler !== null ],
+            [ 'audioDeviceModuleSetWillReleaseEngineActive', this.willReleaseEngineHandler !== null ],
+        ];
+
+        for (const [ method, isActive ] of activeFlags) {
+            this.pushHandlerActive(method, isActive);
         }
     }
 

--- a/src/AudioDeviceModuleEvents.ts
+++ b/src/AudioDeviceModuleEvents.ts
@@ -209,7 +209,15 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setEngineCreatedHandler(handler: AudioEngineEventNoParamsHandler | null) {
+        const wasActive = this.engineCreatedHandler !== null;
+
         this.engineCreatedHandler = handler;
+        const isActive = this.engineCreatedHandler !== null;
+
+        // Notify native about active state change to avoid unnecessary JS round trips
+        if (wasActive !== isActive && WebRTCModule) {
+            WebRTCModule.audioDeviceModuleSetEngineCreatedActive(isActive);
+        }
     }
 
     /**
@@ -217,7 +225,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setWillEnableEngineHandler(handler: AudioEngineEventHandler | null) {
+        const wasActive = this.willEnableEngineHandler !== null;
+
         this.willEnableEngineHandler = handler;
+        const isActive = this.willEnableEngineHandler !== null;
+
+        if (wasActive !== isActive && WebRTCModule) {
+            WebRTCModule.audioDeviceModuleSetWillEnableEngineActive(isActive);
+        }
     }
 
     /**
@@ -225,7 +240,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setWillStartEngineHandler(handler: AudioEngineEventHandler | null) {
+        const wasActive = this.willStartEngineHandler !== null;
+
         this.willStartEngineHandler = handler;
+        const isActive = this.willStartEngineHandler !== null;
+
+        if (wasActive !== isActive && WebRTCModule) {
+            WebRTCModule.audioDeviceModuleSetWillStartEngineActive(isActive);
+        }
     }
 
     /**
@@ -233,7 +255,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setDidStopEngineHandler(handler: AudioEngineEventHandler | null) {
+        const wasActive = this.didStopEngineHandler !== null;
+
         this.didStopEngineHandler = handler;
+        const isActive = this.didStopEngineHandler !== null;
+
+        if (wasActive !== isActive && WebRTCModule) {
+            WebRTCModule.audioDeviceModuleSetDidStopEngineActive(isActive);
+        }
     }
 
     /**
@@ -241,7 +270,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setDidDisableEngineHandler(handler: AudioEngineEventHandler | null) {
+        const wasActive = this.didDisableEngineHandler !== null;
+
         this.didDisableEngineHandler = handler;
+        const isActive = this.didDisableEngineHandler !== null;
+
+        if (wasActive !== isActive && WebRTCModule) {
+            WebRTCModule.audioDeviceModuleSetDidDisableEngineActive(isActive);
+        }
     }
 
     /**
@@ -249,7 +285,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setWillReleaseEngineHandler(handler: AudioEngineEventNoParamsHandler | null) {
+        const wasActive = this.willReleaseEngineHandler !== null;
+
         this.willReleaseEngineHandler = handler;
+        const isActive = this.willReleaseEngineHandler !== null;
+
+        if (wasActive !== isActive && WebRTCModule) {
+            WebRTCModule.audioDeviceModuleSetWillReleaseEngineActive(isActive);
+        }
     }
 }
 

--- a/src/AudioDeviceModuleEvents.ts
+++ b/src/AudioDeviceModuleEvents.ts
@@ -243,18 +243,41 @@ class AudioDeviceModuleEventEmitter {
     }
 
     /**
+     * Apply a handler change while keeping the native active flag ordered so a
+     * delegate callback racing registration can never skip a handler that exists.
+     *
+     * On activation (null to non-null) the flag is pushed active *before* the
+     * handler is published, so the worst case is a JS round trip whose listener
+     * sees the not-yet-published handler and resolves 0, never a skipped veto. On
+     * deactivation the handler is cleared first, then the flag pushed inactive, so
+     * the same safe ordering holds in reverse. No push happens when active state
+     * is unchanged.
+     */
+    private applyHandlerActive(method: string, wasActive: boolean, isActive: boolean, assign: () => void) {
+        if (isActive && !wasActive) {
+            this.pushHandlerActive(method, true);
+        }
+
+        assign();
+
+        if (!isActive && wasActive) {
+            this.pushHandlerActive(method, false);
+        }
+    }
+
+    /**
      * Set handler for engine created delegate - MUST return 0 for success or error code
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setEngineCreatedHandler(handler: AudioEngineEventNoParamsHandler | null) {
-        const wasActive = this.engineCreatedHandler !== null;
-
-        this.engineCreatedHandler = handler;
-        const isActive = this.engineCreatedHandler !== null;
-
-        if (wasActive !== isActive) {
-            this.pushHandlerActive('audioDeviceModuleSetEngineCreatedActive', isActive);
-        }
+        this.applyHandlerActive(
+            'audioDeviceModuleSetEngineCreatedActive',
+            this.engineCreatedHandler !== null,
+            handler !== null,
+            () => {
+                this.engineCreatedHandler = handler;
+            },
+        );
     }
 
     /**
@@ -262,14 +285,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setWillEnableEngineHandler(handler: AudioEngineEventHandler | null) {
-        const wasActive = this.willEnableEngineHandler !== null;
-
-        this.willEnableEngineHandler = handler;
-        const isActive = this.willEnableEngineHandler !== null;
-
-        if (wasActive !== isActive) {
-            this.pushHandlerActive('audioDeviceModuleSetWillEnableEngineActive', isActive);
-        }
+        this.applyHandlerActive(
+            'audioDeviceModuleSetWillEnableEngineActive',
+            this.willEnableEngineHandler !== null,
+            handler !== null,
+            () => {
+                this.willEnableEngineHandler = handler;
+            },
+        );
     }
 
     /**
@@ -277,14 +300,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setWillStartEngineHandler(handler: AudioEngineEventHandler | null) {
-        const wasActive = this.willStartEngineHandler !== null;
-
-        this.willStartEngineHandler = handler;
-        const isActive = this.willStartEngineHandler !== null;
-
-        if (wasActive !== isActive) {
-            this.pushHandlerActive('audioDeviceModuleSetWillStartEngineActive', isActive);
-        }
+        this.applyHandlerActive(
+            'audioDeviceModuleSetWillStartEngineActive',
+            this.willStartEngineHandler !== null,
+            handler !== null,
+            () => {
+                this.willStartEngineHandler = handler;
+            },
+        );
     }
 
     /**
@@ -292,14 +315,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setDidStopEngineHandler(handler: AudioEngineEventHandler | null) {
-        const wasActive = this.didStopEngineHandler !== null;
-
-        this.didStopEngineHandler = handler;
-        const isActive = this.didStopEngineHandler !== null;
-
-        if (wasActive !== isActive) {
-            this.pushHandlerActive('audioDeviceModuleSetDidStopEngineActive', isActive);
-        }
+        this.applyHandlerActive(
+            'audioDeviceModuleSetDidStopEngineActive',
+            this.didStopEngineHandler !== null,
+            handler !== null,
+            () => {
+                this.didStopEngineHandler = handler;
+            },
+        );
     }
 
     /**
@@ -307,14 +330,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setDidDisableEngineHandler(handler: AudioEngineEventHandler | null) {
-        const wasActive = this.didDisableEngineHandler !== null;
-
-        this.didDisableEngineHandler = handler;
-        const isActive = this.didDisableEngineHandler !== null;
-
-        if (wasActive !== isActive) {
-            this.pushHandlerActive('audioDeviceModuleSetDidDisableEngineActive', isActive);
-        }
+        this.applyHandlerActive(
+            'audioDeviceModuleSetDidDisableEngineActive',
+            this.didDisableEngineHandler !== null,
+            handler !== null,
+            () => {
+                this.didDisableEngineHandler = handler;
+            },
+        );
     }
 
     /**
@@ -322,14 +345,14 @@ class AudioDeviceModuleEventEmitter {
      * This handler blocks the native thread until it returns, throw to cancel audio engine's operation
      */
     setWillReleaseEngineHandler(handler: AudioEngineEventNoParamsHandler | null) {
-        const wasActive = this.willReleaseEngineHandler !== null;
-
-        this.willReleaseEngineHandler = handler;
-        const isActive = this.willReleaseEngineHandler !== null;
-
-        if (wasActive !== isActive) {
-            this.pushHandlerActive('audioDeviceModuleSetWillReleaseEngineActive', isActive);
-        }
+        this.applyHandlerActive(
+            'audioDeviceModuleSetWillReleaseEngineActive',
+            this.willReleaseEngineHandler !== null,
+            handler !== null,
+            () => {
+                this.willReleaseEngineHandler = handler;
+            },
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Builds on #90 (the bounded-wait deadlock fix) to remove the JS round-trip entirely for AudioDeviceModule engine hooks that have no registered handler, instead of only bounding the wait. For those hooks this closes the deadlock window rather than capping it at 2 seconds.

Stacked on #90. This PR targets the #90 branch, so it should land after #90 and the diff here is only the delta on top.

## Background

#90 bounds each of the six RTCAudioDeviceModule delegate waits to 2 seconds so a stuck JS thread can no longer freeze the app forever. But a hook with no JS handler has nothing to wait for, so blocking it at all is pure risk with no benefit.

## Change

Track per-hook handler registration with is-prefixed BOOL active flags. The JS layer pushes a flag to native whenever a handler is set or cleared. When a hook is inactive the observer returns 0 immediately without sending the event or waiting, so the unhandled hooks never enter the blocking path and cannot contribute to the deadlock.

In stock config this removes engineCreated, willStart, didStop and willRelease from the blocking path entirely, including willStart, which appeared in both reported freeze traces. The two hooks LiveKit registers by default (willEnable and didDisable) keep the bounded-wait and request-id safety net from #90.

The flags are written on the JS thread (handler registration) and read on the native audio thread (delegate callbacks), so they are declared atomic. The multi-field request-id state stays under @synchronized because it needs a true critical section.

## Scope

Self-contained in this package. The active flags and request ids are internal to react-native-webrtc and never reach app handlers, so the public handler API is unchanged and no changes are needed in @livekit/react-native.

## Testing

- npm run lint (eslint and tsc) passes.
- clang-format check passes.
- iOS and Android native builds run in CI.

Refs #89, livekit/client-sdk-react-native#389.
