### PR TITLE
release: 144.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "144.1.0",
+  "version": "144.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@livekit/react-native-webrtc",
-      "version": "144.1.0",
+      "version": "144.1.1",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "144.1.0",
+  "version": "144.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/livekit/react-native-webrtc.git"


### PR DESCRIPTION
a95d57d fix(ios): skip AudioDeviceModule JS round-trips when no handler is registered (#91)  ( Hiroshi Horie 2026-06-18 16:20:29 +0900)
c751bd6 ios: bump WebRTC-SDK to 144.7559.10 (#92)  ( Hiroshi Horie 2026-06-18 16:11:31 +0900)
196cbb3 fix(ios): bound AudioDeviceModuleObserver JS waits to break the deadlock (#90)  ( Hiroshi Horie 2026-06-18 03:49:07 +0900)