### PR TITLE
chore: use LiveKitWebRTC

### DIFF
--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.h
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.h
@@ -1,9 +1,9 @@
-#import <WebRTC/WebRTC.h>
+#import <LiveKitWebRTC/LiveKitWebRTC.h>
 #import "WebRTCModule.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface AudioDeviceModuleObserver : NSObject<RTCAudioDeviceModuleDelegate>
+@interface AudioDeviceModuleObserver : NSObject<LKRTCAudioDeviceModuleDelegate>
 
 - (instancetype)initWithWebRTCModule:(WebRTCModule *)module;
 

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -146,11 +146,11 @@ static os_log_t ADMObserverLog(void) {
     return resultBlock();
 }
 
-#pragma mark - RTCAudioDeviceModuleDelegate
+#pragma mark - LKRTCAudioDeviceModuleDelegate
 
-- (void)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
-    didReceiveSpeechActivityEvent:(RTCSpeechActivityEvent)speechActivityEvent {
-    NSString *eventType = speechActivityEvent == RTCSpeechActivityEventStarted ? @"started" : @"ended";
+- (void)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
+    didReceiveSpeechActivityEvent:(LKRTCSpeechActivityEvent)speechActivityEvent {
+    NSString *eventType = speechActivityEvent == LKRTCSpeechActivityEventStarted ? @"started" : @"ended";
 
     [self.module sendEventWithName:kEventAudioDeviceModuleSpeechActivity
                               body:@{
@@ -160,7 +160,7 @@ static os_log_t ADMObserverLog(void) {
     RCTLog(@"[AudioDeviceModuleObserver] Speech activity event: %@", eventType);
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule didCreateEngine:(AVAudioEngine *)engine {
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule didCreateEngine:(AVAudioEngine *)engine {
     BOOL isActive = self.isEngineCreatedActive;
 
     if (isActive) {
@@ -181,7 +181,7 @@ static os_log_t ADMObserverLog(void) {
     return result;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
               willEnableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
@@ -214,7 +214,7 @@ static os_log_t ADMObserverLog(void) {
     return result;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
                willStartEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
@@ -243,7 +243,7 @@ static os_log_t ADMObserverLog(void) {
     return result;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
                  didStopEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
@@ -272,7 +272,7 @@ static os_log_t ADMObserverLog(void) {
     return result;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
               didDisableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
@@ -301,7 +301,7 @@ static os_log_t ADMObserverLog(void) {
     return result;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule willReleaseEngine:(AVAudioEngine *)engine {
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule willReleaseEngine:(AVAudioEngine *)engine {
     BOOL isActive = self.isWillReleaseEngineActive;
 
     if (isActive) {
@@ -322,7 +322,7 @@ static os_log_t ADMObserverLog(void) {
     return result;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
                         engine:(AVAudioEngine *)engine
       configureInputFromSource:(nullable AVAudioNode *)source
                  toDestination:(AVAudioNode *)destination
@@ -332,7 +332,7 @@ static os_log_t ADMObserverLog(void) {
     return 0;
 }
 
-- (NSInteger)audioDeviceModule:(RTCAudioDeviceModule *)audioDeviceModule
+- (NSInteger)audioDeviceModule:(LKRTCAudioDeviceModule *)audioDeviceModule
                         engine:(AVAudioEngine *)engine
      configureOutputFromSource:(AVAudioNode *)source
                  toDestination:(nullable AVAudioNode *)destination
@@ -342,7 +342,7 @@ static os_log_t ADMObserverLog(void) {
     return 0;
 }
 
-- (void)audioDeviceModuleDidUpdateDevices:(RTCAudioDeviceModule *)audioDeviceModule {
+- (void)audioDeviceModuleDidUpdateDevices:(LKRTCAudioDeviceModule *)audioDeviceModule {
     [self.module sendEventWithName:kEventAudioDeviceModuleDevicesUpdated body:@{}];
 
     RCTLog(@"[AudioDeviceModuleObserver] Devices updated");

--- a/ios/RCTWebRTC/CapturerEventsDelegate.h
+++ b/ios/RCTWebRTC/CapturerEventsDelegate.h
@@ -1,11 +1,11 @@
-#import <WebRTC/RTCVideoCapturer.h>
+#import <LiveKitWebRTC/RTCVideoCapturer.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol CapturerEventsDelegate
 
 /** Called when the capturer is ended and in an irrecoverable state. */
-- (void)capturerDidEnd:(RTCVideoCapturer *)capturer;
+- (void)capturerDidEnd:(LKRTCVideoCapturer *)capturer;
 
 @end
 

--- a/ios/RCTWebRTC/DataChannelWrapper.h
+++ b/ios/RCTWebRTC/DataChannelWrapper.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <WebRTC/RTCDataChannel.h>
+#import <LiveKitWebRTC/RTCDataChannel.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,17 +8,17 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol DataChannelWrapperDelegate<NSObject>
 
 - (void)dataChannelDidChangeState:(DataChannelWrapper *)dataChannelWrapper;
-- (void)dataChannel:(DataChannelWrapper *)dataChannelWrapper didReceiveMessageWithBuffer:(RTCDataBuffer *)buffer;
+- (void)dataChannel:(DataChannelWrapper *)dataChannelWrapper didReceiveMessageWithBuffer:(LKRTCDataBuffer *)buffer;
 - (void)dataChannel:(DataChannelWrapper *)dataChannelWrapper didChangeBufferedAmount:(uint64_t)amount;
 
 @end
 
 @interface DataChannelWrapper : NSObject
 
-- (instancetype)initWithChannel:(RTCDataChannel *)channel reactTag:(NSString *)tag;
+- (instancetype)initWithChannel:(LKRTCDataChannel *)channel reactTag:(NSString *)tag;
 
 @property(nonatomic, nonnull, copy) NSNumber *pcId;
-@property(nonatomic, nonnull, readonly) RTCDataChannel *channel;
+@property(nonatomic, nonnull, readonly) LKRTCDataChannel *channel;
 @property(nonatomic, nonnull, readonly) NSString *reactTag;
 @property(nonatomic, nullable, weak) id<DataChannelWrapperDelegate> delegate;
 

--- a/ios/RCTWebRTC/DataChannelWrapper.m
+++ b/ios/RCTWebRTC/DataChannelWrapper.m
@@ -1,14 +1,14 @@
 
 #import "DataChannelWrapper.h"
 
-#import <WebRTC/RTCDataChannel.h>
+#import <LiveKitWebRTC/RTCDataChannel.h>
 
-@interface DataChannelWrapper ()<RTCDataChannelDelegate>
+@interface DataChannelWrapper ()<LKRTCDataChannelDelegate>
 @end
 
 @implementation DataChannelWrapper
 
-- (instancetype)initWithChannel:(RTCDataChannel *)channel reactTag:(NSString *)tag {
+- (instancetype)initWithChannel:(LKRTCDataChannel *)channel reactTag:(NSString *)tag {
     self = [super init];
     if (self) {
         _channel = channel;
@@ -21,19 +21,19 @@
     return self;
 }
 
-- (void)dataChannel:(nonnull RTCDataChannel *)dataChannel didReceiveMessageWithBuffer:(nonnull RTCDataBuffer *)buffer {
+- (void)dataChannel:(nonnull LKRTCDataChannel *)dataChannel didReceiveMessageWithBuffer:(nonnull LKRTCDataBuffer *)buffer {
     if (_delegate) {
         [_delegate dataChannel:self didReceiveMessageWithBuffer:buffer];
     }
 }
 
-- (void)dataChannelDidChangeState:(nonnull RTCDataChannel *)dataChannel {
+- (void)dataChannelDidChangeState:(nonnull LKRTCDataChannel *)dataChannel {
     if (_delegate) {
         [_delegate dataChannelDidChangeState:self];
     }
 }
 
-- (void)dataChannel:(nonnull RTCDataChannel *)dataChannel didChangeBufferedAmount:(uint64_t)amount {
+- (void)dataChannel:(nonnull LKRTCDataChannel *)dataChannel didChangeBufferedAmount:(uint64_t)amount {
     if (_delegate) {
         [_delegate dataChannel:self didChangeBufferedAmount:amount];
     }

--- a/ios/RCTWebRTC/I420Converter.h
+++ b/ios/RCTWebRTC/I420Converter.h
@@ -10,13 +10,13 @@
 
 #import <Accelerate/Accelerate.h>
 #import <UIKit/UIKit.h>
-#import <WebRTC/WebRTC.h>
+#import <LiveKitWebRTC/LiveKitWebRTC.h>
 
 @interface I420Converter : NSObject
 
 - (vImage_Error)prepareForAccelerateConversion;
 - (void)unprepareForAccelerateConversion;
-- (CVPixelBufferRef)convertI420ToPixelBuffer:(RTCI420Buffer *)buffer;
+- (CVPixelBufferRef)convertI420ToPixelBuffer:(LKRTCI420Buffer *)buffer;
 - (void)createPixelBufferPoolWithWidth:(size_t)width height:(size_t)height;
 
 @end

--- a/ios/RCTWebRTC/I420Converter.m
+++ b/ios/RCTWebRTC/I420Converter.m
@@ -78,7 +78,7 @@
     }
 }
 
-- (CVPixelBufferRef)convertI420ToPixelBuffer:(RTCI420Buffer *)buffer {
+- (CVPixelBufferRef)convertI420ToPixelBuffer:(LKRTCI420Buffer *)buffer {
     if (_conversionInfo == nil) {
         NSLog(@"%@: not prepared", NSStringFromSelector(_cmd));
         return NULL;
@@ -106,7 +106,7 @@
     return pixelBuffer;
 }
 
-- (vImage_Error)convertFrameVImageYUV:(RTCI420Buffer *)buffer toBuffer:(CVPixelBufferRef)pixelBufferRef {
+- (vImage_Error)convertFrameVImageYUV:(LKRTCI420Buffer *)buffer toBuffer:(CVPixelBufferRef)pixelBufferRef {
     if (pixelBufferRef == NULL) {
         return kvImageInvalidParameter;
     }

--- a/ios/RCTWebRTC/PIPController.h
+++ b/ios/RCTWebRTC/PIPController.h
@@ -1,6 +1,6 @@
 #import <AVKit/AVKit.h>
 #import <UIKit/UIKit.h>
-#import <WebRTC/RTCVideoTrack.h>
+#import <LiveKitWebRTC/RTCVideoTrack.h>
 
 #import "RTCVideoViewManager.h"
 
@@ -8,7 +8,7 @@ API_AVAILABLE(ios(15.0))
 @interface PIPController : NSObject<AVPictureInPictureControllerDelegate>
 
 @property(nonatomic, weak) UIView *sourceView;
-@property(nonatomic, strong) RTCVideoTrack *videoTrack;
+@property(nonatomic, strong) LKRTCVideoTrack *videoTrack;
 
 @property(nonatomic, assign) BOOL startAutomatically;
 @property(nonatomic, assign) BOOL stopAutomatically;

--- a/ios/RCTWebRTC/PIPController.m
+++ b/ios/RCTWebRTC/PIPController.m
@@ -79,7 +79,7 @@
     [NSLayoutConstraint activateConstraints:constraints];
 }
 
-- (void)setVideoTrack:(RTCVideoTrack *)videoTrack {
+- (void)setVideoTrack:(LKRTCVideoTrack *)videoTrack {
     if (_videoTrack != videoTrack) {
         [_videoTrack removeRenderer:_sampleView];
     }

--- a/ios/RCTWebRTC/RCTConvert+WebRTC.h
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.h
@@ -1,16 +1,16 @@
 #import <React/RCTConvert.h>
-#import <WebRTC/RTCConfiguration.h>
-#import <WebRTC/RTCDataChannelConfiguration.h>
-#import <WebRTC/RTCIceCandidate.h>
-#import <WebRTC/RTCIceServer.h>
-#import <WebRTC/RTCSessionDescription.h>
+#import <LiveKitWebRTC/RTCConfiguration.h>
+#import <LiveKitWebRTC/RTCDataChannelConfiguration.h>
+#import <LiveKitWebRTC/RTCIceCandidate.h>
+#import <LiveKitWebRTC/RTCIceServer.h>
+#import <LiveKitWebRTC/RTCSessionDescription.h>
 
 @interface RCTConvert (WebRTC)
 
-+ (RTCIceCandidate *)RTCIceCandidate:(id)json;
-+ (RTCSessionDescription *)RTCSessionDescription:(id)json;
-+ (RTCIceServer *)RTCIceServer:(id)json;
-+ (RTCDataChannelConfiguration *)RTCDataChannelConfiguration:(id)json;
-+ (RTCConfiguration *)RTCConfiguration:(id)json;
++ (LKRTCIceCandidate *)LKRTCIceCandidate:(id)json;
++ (LKRTCSessionDescription *)LKRTCSessionDescription:(id)json;
++ (LKRTCIceServer *)LKRTCIceServer:(id)json;
++ (LKRTCDataChannelConfiguration *)LKRTCDataChannelConfiguration:(id)json;
++ (LKRTCConfiguration *)LKRTCConfiguration:(id)json;
 
 @end

--- a/ios/RCTWebRTC/RCTConvert+WebRTC.m
+++ b/ios/RCTWebRTC/RCTConvert+WebRTC.m
@@ -1,12 +1,12 @@
 #import <React/RCTLog.h>
-#import <WebRTC/RTCDataChannelConfiguration.h>
-#import <WebRTC/RTCIceServer.h>
-#import <WebRTC/RTCSessionDescription.h>
+#import <LiveKitWebRTC/RTCDataChannelConfiguration.h>
+#import <LiveKitWebRTC/RTCIceServer.h>
+#import <LiveKitWebRTC/RTCSessionDescription.h>
 #import "RCTConvert+WebRTC.h"
 
 @implementation RCTConvert (WebRTC)
 
-+ (RTCSessionDescription *)RTCSessionDescription:(id)json {
++ (LKRTCSessionDescription *)LKRTCSessionDescription:(id)json {
     if (!json) {
         return nil;
     }
@@ -22,12 +22,12 @@
     }
 
     NSString *sdp = json[@"sdp"];
-    RTCSdpType sdpType = [RTCSessionDescription typeForString:json[@"type"]];
+    LKRTCSdpType sdpType = [LKRTCSessionDescription typeForString:json[@"type"]];
 
-    return [[RTCSessionDescription alloc] initWithType:sdpType sdp:sdp];
+    return [[LKRTCSessionDescription alloc] initWithType:sdpType sdp:sdp];
 }
 
-+ (RTCIceCandidate *)RTCIceCandidate:(id)json {
++ (LKRTCIceCandidate *)LKRTCIceCandidate:(id)json {
     if (!json) {
         RCTLogConvertError(json, @"must not be null");
         return nil;
@@ -53,10 +53,10 @@
     int sdpMLineIndex = [RCTConvert int:json[@"sdpMLineIndex"]];
     NSString *sdpMid = json[@"sdpMid"];
 
-    return [[RTCIceCandidate alloc] initWithSdp:sdp sdpMLineIndex:sdpMLineIndex sdpMid:sdpMid];
+    return [[LKRTCIceCandidate alloc] initWithSdp:sdp sdpMLineIndex:sdpMLineIndex sdpMid:sdpMid];
 }
 
-+ (RTCIceServer *)RTCIceServer:(id)json {
++ (LKRTCIceServer *)LKRTCIceServer:(id)json {
     if (!json) {
         RCTLogConvertError(json, @"a valid iceServer value");
         return nil;
@@ -75,21 +75,21 @@
     }
 
     if (json[@"username"] != nil || json[@"credential"] != nil) {
-        return [[RTCIceServer alloc] initWithURLStrings:urls username:json[@"username"] credential:json[@"credential"]];
+        return [[LKRTCIceServer alloc] initWithURLStrings:urls username:json[@"username"] credential:json[@"credential"]];
     }
 
-    return [[RTCIceServer alloc] initWithURLStrings:urls];
+    return [[LKRTCIceServer alloc] initWithURLStrings:urls];
 }
 
-+ (nonnull RTCConfiguration *)RTCConfiguration:(id)json {
-    RTCConfiguration *config = [[RTCConfiguration alloc] init];
-    config.sdpSemantics = RTCSdpSemanticsUnifiedPlan;
++ (nonnull LKRTCConfiguration *)LKRTCConfiguration:(id)json {
+    LKRTCConfiguration *config = [[LKRTCConfiguration alloc] init];
+    config.sdpSemantics = LKRTCSdpSemanticsUnifiedPlan;
 
     // Required for perfect negotiation.
     config.enableImplicitRollback = YES;
 
     // Enable GCM ciphers.
-    RTCCryptoOptions *cryptoOptions = [[RTCCryptoOptions alloc] initWithSrtpEnableGcmCryptoSuites:YES
+    LKRTCCryptoOptions *cryptoOptions = [[LKRTCCryptoOptions alloc] initWithSrtpEnableGcmCryptoSuites:YES
                                                               srtpEnableAes128Sha1_32CryptoCipher:NO
                                                            srtpEnableEncryptedRtpHeaderExtensions:NO
                                                                      sframeRequireFrameEncryption:NO];
@@ -112,11 +112,11 @@
     if (json[@"bundlePolicy"] != nil && [json[@"bundlePolicy"] isKindOfClass:[NSString class]]) {
         NSString *bundlePolicy = json[@"bundlePolicy"];
         if ([bundlePolicy isEqualToString:@"balanced"]) {
-            config.bundlePolicy = RTCBundlePolicyBalanced;
+            config.bundlePolicy = LKRTCBundlePolicyBalanced;
         } else if ([bundlePolicy isEqualToString:@"max-compat"]) {
-            config.bundlePolicy = RTCBundlePolicyMaxCompat;
+            config.bundlePolicy = LKRTCBundlePolicyMaxCompat;
         } else if ([bundlePolicy isEqualToString:@"max-bundle"]) {
-            config.bundlePolicy = RTCBundlePolicyMaxBundle;
+            config.bundlePolicy = LKRTCBundlePolicyMaxBundle;
         }
     }
 
@@ -131,9 +131,9 @@
     }
 
     if (json[@"iceServers"] != nil && [json[@"iceServers"] isKindOfClass:[NSArray class]]) {
-        NSMutableArray<RTCIceServer *> *iceServers = [NSMutableArray new];
+        NSMutableArray<LKRTCIceServer *> *iceServers = [NSMutableArray new];
         for (id server in json[@"iceServers"]) {
-            RTCIceServer *convert = [RCTConvert RTCIceServer:server];
+            LKRTCIceServer *convert = [RCTConvert LKRTCIceServer:server];
             if (convert != nil) {
                 [iceServers addObject:convert];
             }
@@ -144,43 +144,43 @@
     if (json[@"iceTransportPolicy"] != nil && [json[@"iceTransportPolicy"] isKindOfClass:[NSString class]]) {
         NSString *iceTransportPolicy = json[@"iceTransportPolicy"];
         if ([iceTransportPolicy isEqualToString:@"all"]) {
-            config.iceTransportPolicy = RTCIceTransportPolicyAll;
+            config.iceTransportPolicy = LKRTCIceTransportPolicyAll;
         } else if ([iceTransportPolicy isEqualToString:@"none"]) {
-            config.iceTransportPolicy = RTCIceTransportPolicyNone;
+            config.iceTransportPolicy = LKRTCIceTransportPolicyNone;
         } else if ([iceTransportPolicy isEqualToString:@"nohost"]) {
-            config.iceTransportPolicy = RTCIceTransportPolicyNoHost;
+            config.iceTransportPolicy = LKRTCIceTransportPolicyNoHost;
         } else if ([iceTransportPolicy isEqualToString:@"relay"]) {
-            config.iceTransportPolicy = RTCIceTransportPolicyRelay;
+            config.iceTransportPolicy = LKRTCIceTransportPolicyRelay;
         }
     }
 
     if (json[@"rtcpMuxPolicy"] != nil && [json[@"rtcpMuxPolicy"] isKindOfClass:[NSString class]]) {
         NSString *rtcpMuxPolicy = json[@"rtcpMuxPolicy"];
         if ([rtcpMuxPolicy isEqualToString:@"negotiate"]) {
-            config.rtcpMuxPolicy = RTCRtcpMuxPolicyNegotiate;
+            config.rtcpMuxPolicy = LKRTCRtcpMuxPolicyNegotiate;
         } else if ([rtcpMuxPolicy isEqualToString:@"require"]) {
-            config.rtcpMuxPolicy = RTCRtcpMuxPolicyRequire;
+            config.rtcpMuxPolicy = LKRTCRtcpMuxPolicyRequire;
         }
     }
 
     if (json[@"tcpCandidatePolicy"] != nil && [json[@"tcpCandidatePolicy"] isKindOfClass:[NSString class]]) {
         NSString *tcpCandidatePolicy = json[@"tcpCandidatePolicy"];
         if ([tcpCandidatePolicy isEqualToString:@"enabled"]) {
-            config.tcpCandidatePolicy = RTCTcpCandidatePolicyEnabled;
+            config.tcpCandidatePolicy = LKRTCTcpCandidatePolicyEnabled;
         } else if ([tcpCandidatePolicy isEqualToString:@"disabled"]) {
-            config.tcpCandidatePolicy = RTCTcpCandidatePolicyDisabled;
+            config.tcpCandidatePolicy = LKRTCTcpCandidatePolicyDisabled;
         }
     }
 
     return config;
 }
 
-+ (RTCDataChannelConfiguration *)RTCDataChannelConfiguration:(id)json {
++ (LKRTCDataChannelConfiguration *)LKRTCDataChannelConfiguration:(id)json {
     if (!json) {
         return nil;
     }
     if ([json isKindOfClass:[NSDictionary class]]) {
-        RTCDataChannelConfiguration *init = [RTCDataChannelConfiguration new];
+        LKRTCDataChannelConfiguration *init = [LKRTCDataChannelConfiguration new];
 
         if (json[@"id"]) {
             [init setChannelId:[RCTConvert int:json[@"id"]]];

--- a/ios/RCTWebRTC/RTCMediaStreamTrack+React.h
+++ b/ios/RCTWebRTC/RTCMediaStreamTrack+React.h
@@ -1,9 +1,9 @@
 
-#import <WebRTC/RTCMediaStreamTrack.h>
+#import <LiveKitWebRTC/RTCMediaStreamTrack.h>
 
 @class CaptureController;
 
-@interface RTCMediaStreamTrack (React)
+@interface LKRTCMediaStreamTrack (React)
 
 @property(strong, nonatomic) CaptureController *captureController;
 

--- a/ios/RCTWebRTC/RTCMediaStreamTrack+React.m
+++ b/ios/RCTWebRTC/RTCMediaStreamTrack+React.m
@@ -3,7 +3,7 @@
 #import "CaptureController.h"
 #import "RTCMediaStreamTrack+React.h"
 
-@implementation RTCMediaStreamTrack (React)
+@implementation LKRTCMediaStreamTrack (React)
 
 - (CaptureController *)captureController {
     return objc_getAssociatedObject(self, @selector(captureController));

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -5,15 +5,15 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTView.h>
 
-#import <WebRTC/RTCMediaStream.h>
+#import <LiveKitWebRTC/RTCMediaStream.h>
 #if TARGET_OS_OSX
-#import <WebRTC/RTCMTLNSVideoView.h>
+#import <LiveKitWebRTC/RTCMTLNSVideoView.h>
 #else
-#import <WebRTC/RTCMTLVideoView.h>
+#import <LiveKitWebRTC/RTCMTLVideoView.h>
 #endif
-#import <WebRTC/RTCCVPixelBuffer.h>
-#import <WebRTC/RTCVideoFrame.h>
-#import <WebRTC/RTCVideoTrack.h>
+#import <LiveKitWebRTC/RTCCVPixelBuffer.h>
+#import <LiveKitWebRTC/RTCVideoFrame.h>
+#import <LiveKitWebRTC/RTCVideoTrack.h>
 
 #import "PIPController.h"
 #import "RTCVideoViewManager.h"
@@ -23,7 +23,7 @@
  * Implements an equivalent of {@code HTMLVideoElement} i.e. Web's video
  * element.
  */
-@interface RTCVideoView : RCTView<RTCVideoViewDelegate>
+@interface RTCVideoView : RCTView<LKRTCVideoViewDelegate>
 
 /**
  * The indicator which determines whether this {@code RTCVideoView} is to mirror
@@ -48,18 +48,18 @@
  * The {@link RRTCVideoRenderer} which implements the actual rendering.
  */
 #if TARGET_OS_OSX
-@property(nonatomic, readonly) RTCMTLNSVideoView *videoView;
+@property(nonatomic, readonly) LKRTCMTLNSVideoView *videoView;
 #else
-@property(nonatomic, readonly) RTCMTLVideoView *videoView;
+@property(nonatomic, readonly) LKRTCMTLVideoView *videoView;
 #endif
 
 // Add a reference to the view manager
 @property(nonatomic, weak) RTCVideoViewManager *viewManager;
 
 /**
- * The {@link RTCVideoTrack}, if any, which this instance renders.
+ * The {@link LKRTCVideoTrack}, if any, which this instance renders.
  */
-@property(nonatomic, strong) RTCVideoTrack *videoTrack;
+@property(nonatomic, strong) LKRTCVideoTrack *videoTrack;
 
 /**
  * Reference to the main WebRTC RN module.
@@ -80,12 +80,12 @@
  */
 - (void)didMoveToWindow {
     // This RTCVideoView strongly retains its videoTrack. The latter strongly
-    // retains the former as well though because RTCVideoTrack strongly retains
+    // retains the former as well though because LKRTCVideoTrack strongly retains
     // the RTCVideoRenderers added to it. In other words, there is a cycle of
     // strong retainments. In order to break the cycle, and avoid a leak,
-    // have this RTCVideoView as the RTCVideoRenderer of its
+    // have this RTCVideoView as the LKRTCVideoRenderer of its
     // videoTrack only while this view resides in a window.
-    RTCVideoTrack *videoTrack = self.videoTrack;
+    LKRTCVideoTrack *videoTrack = self.videoTrack;
 
     if (videoTrack) {
         if (self.window) {
@@ -109,11 +109,11 @@
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
 #if TARGET_OS_OSX
-        RTCMTLNSVideoView *subview = [[RTCMTLNSVideoView alloc] initWithFrame:CGRectZero];
+        LKRTCMTLNSVideoView *subview = [[LKRTCMTLNSVideoView alloc] initWithFrame:CGRectZero];
         subview.wantsLayer = true;
         _videoView = subview;
 #else
-        RTCMTLVideoView *subview = [[RTCMTLVideoView alloc] initWithFrame:CGRectZero];
+        LKRTCMTLVideoView *subview = [[LKRTCMTLVideoView alloc] initWithFrame:CGRectZero];
         _videoView = subview;
 #endif
         _objectFit = RTCVideoViewObjectFitCover;
@@ -242,8 +242,8 @@
  * @param videoTrack The value to set on the {@code videoTrack} property of this
  * {@code RTCVideoView}.
  */
-- (void)setVideoTrack:(RTCVideoTrack *)videoTrack {
-    RTCVideoTrack *oldValue = self.videoTrack;
+- (void)setVideoTrack:(LKRTCVideoTrack *)videoTrack {
+    LKRTCVideoTrack *oldValue = self.videoTrack;
 
     if (oldValue != videoTrack) {
         if (oldValue) {
@@ -279,9 +279,9 @@
 
             CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
             int64_t time = (int64_t)(CFAbsoluteTimeGetCurrent() * 1000000000);
-            RTCCVPixelBuffer *buffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
-            RTCVideoFrame *frame = [[[RTCVideoFrame alloc] initWithBuffer:buffer
-                                                                 rotation:RTCVideoRotation_0
+            LKRTCCVPixelBuffer *buffer = [[LKRTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
+            LKRTCVideoFrame *frame = [[[LKRTCVideoFrame alloc] initWithBuffer:buffer
+                                                                 rotation:LKRTCVideoRotation_0
                                                               timeStampNs:time] newI420VideoFrame];
 
             [self.videoView renderFrame:frame];
@@ -358,9 +358,9 @@ RCT_CUSTOM_VIEW_PROPERTY(streamURL, NSString *, RTCVideoView) {
     WebRTCModule *module = view.module;
 
     dispatch_async(module.workerQueue, ^{
-        RTCMediaStream *stream = [module streamForReactTag:streamReactTag];
+        LKRTCMediaStream *stream = [module streamForReactTag:streamReactTag];
         NSArray *videoTracks = stream ? stream.videoTracks : @[];
-        RTCVideoTrack *videoTrack = [videoTracks firstObject];
+        LKRTCVideoTrack *videoTrack = [videoTracks firstObject];
         if (!videoTrack) {
             RCTLogWarn(@"No video stream for react tag: %@", streamReactTag);
         } else {

--- a/ios/RCTWebRTC/SampleBufferVideoCallView.h
+++ b/ios/RCTWebRTC/SampleBufferVideoCallView.h
@@ -1,9 +1,9 @@
 #import <AVKit/AVKit.h>
 #import <Foundation/Foundation.h>
 #import <React/RCTViewManager.h>
-#import <WebRTC/RTCVideoRenderer.h>
+#import <LiveKitWebRTC/RTCVideoRenderer.h>
 
-@interface SampleBufferVideoCallView : UIView<RTCVideoRenderer>
+@interface SampleBufferVideoCallView : UIView<LKRTCVideoRenderer>
 
 @property(nonnull, nonatomic, readonly) AVSampleBufferDisplayLayer *sampleBufferLayer;
 @property(nonatomic, assign) BOOL shouldRender;

--- a/ios/RCTWebRTC/SampleBufferVideoCallView.m
+++ b/ios/RCTWebRTC/SampleBufferVideoCallView.m
@@ -1,6 +1,6 @@
 #import "SampleBufferVideoCallView.h"
 #import <Accelerate/Accelerate.h>
-#import <WebRTC/WebRTC.h>
+#import <LiveKitWebRTC/LiveKitWebRTC.h>
 #import "I420Converter.h"
 
 @protocol SampleBufferRendering<AVQueuedSampleBufferRendering>
@@ -57,7 +57,7 @@
     _currentRotation = -1;
 }
 
-- (void)recalculateScale:(RTCVideoRotation)rotation {
+- (void)recalculateScale:(LKRTCVideoRotation)rotation {
     if (self.currentRotation != rotation) {
         self.currentRotation = rotation;
 
@@ -77,12 +77,12 @@
 }
 
 /** The frame to be displayed. */
-- (void)renderFrame:(nullable RTC_OBJC_TYPE(RTCVideoFrame) *)frame {
+- (void)renderFrame:(nullable RTC_OBJC_TYPE(LKRTCVideoFrame) *)frame {
     if (!_shouldRender) {
         return;
     }
 
-    // Convert RTCVideoFrame to CMSampleBuffer
+    // Convert LKRTCVideoFrame to CMSampleBuffer
     CMSampleBufferRef sampleBuffer = [self sampleBufferFrom:frame];
     if (sampleBuffer == nil) {
         return;
@@ -105,10 +105,10 @@
     });
 }
 
-- (CMSampleBufferRef)sampleBufferFrom:(RTCVideoFrame *)rtcVideoFrame {
-    // Convert RTCVideoFrame to CMSampleBuffer
+- (CMSampleBufferRef)sampleBufferFrom:(LKRTCVideoFrame *)rtcVideoFrame {
+    // Convert LKRTCVideoFrame to CMSampleBuffer
 
-    // Assuming your RTCVideoFrame contains pixelBuffer
+    // Assuming your LKRTCVideoFrame contains pixelBuffer
     CVPixelBufferRef pixelBuffer = [self pixelBufferFrom:rtcVideoFrame];
     if (!pixelBuffer) {
         return nil;
@@ -119,7 +119,7 @@
     CMVideoFormatDescriptionCreateForImageBuffer(kCFAllocatorDefault, pixelBuffer, &formatDescription);
 
     // Create CMSampleTimingInfo
-    // Timescale is 90khz according to RTCVideoFrame.h
+    // Timescale is 90khz according to LKRTCVideoFrame.h
     CMSampleTimingInfo timingInfo;
     timingInfo.presentationTimeStamp = CMTimeMake(rtcVideoFrame.timeStamp, 90000);
     timingInfo.decodeTimeStamp = CMTimeMake(rtcVideoFrame.timeStamp, 90000);
@@ -140,11 +140,11 @@
 /**
  * The CVPixelBufferRef returned from this function must be released when finished using it.
  */
-- (CVPixelBufferRef)pixelBufferFrom:(RTCVideoFrame *)videoFrame {
-    if ([videoFrame.buffer isKindOfClass:[RTCCVPixelBuffer class]]) {
-        CVPixelBufferRef pixelBuffer = [((RTCCVPixelBuffer *)videoFrame.buffer) pixelBuffer];
+- (CVPixelBufferRef)pixelBufferFrom:(LKRTCVideoFrame *)videoFrame {
+    if ([videoFrame.buffer isKindOfClass:[LKRTCCVPixelBuffer class]]) {
+        CVPixelBufferRef pixelBuffer = [((LKRTCCVPixelBuffer *)videoFrame.buffer) pixelBuffer];
         CVPixelBufferRetain(pixelBuffer);
-        return [((RTCCVPixelBuffer *)videoFrame.buffer) pixelBuffer];
+        return [((LKRTCCVPixelBuffer *)videoFrame.buffer) pixelBuffer];
     } else {
         return [self pixelBufferFromI420:[videoFrame.buffer toI420]];
     }
@@ -153,7 +153,7 @@
 /**
  * The CVPixelBufferRef returned from this function must be released when finished using it.
  */
-- (CVPixelBufferRef)pixelBufferFromI420:(RTCI420Buffer *)i420Buffer {
+- (CVPixelBufferRef)pixelBufferFromI420:(LKRTCI420Buffer *)i420Buffer {
     if (_i420Converter == nil) {
         I420Converter *converter = [[I420Converter alloc] init];
         vImage_Error err = [converter prepareForAccelerateConversion];

--- a/ios/RCTWebRTC/ScreenCaptureController.h
+++ b/ios/RCTWebRTC/ScreenCaptureController.h
@@ -4,8 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const kRTCScreensharingSocketFD;
-extern NSString *const kRTCAppGroupIdentifier;
+extern NSString *const kLKRTCScreensharingSocketFD;
+extern NSString *const kLKRTCAppGroupIdentifier;
 
 @class ScreenCapturer;
 

--- a/ios/RCTWebRTC/ScreenCaptureController.m
+++ b/ios/RCTWebRTC/ScreenCaptureController.m
@@ -4,8 +4,8 @@
 #import "ScreenCapturer.h"
 #import "SocketConnection.h"
 
-NSString *const kRTCScreensharingSocketFD = @"rtc_SSFD";
-NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
+NSString *const kLKRTCScreensharingSocketFD = @"rtc_SSFD";
+NSString *const kLKRTCAppGroupIdentifier = @"LKRTCAppGroupIdentifier";
 
 @interface ScreenCaptureController ()
 
@@ -14,7 +14,7 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
 @end
 
 @interface ScreenCaptureController (CapturerEventsDelegate)<CapturerEventsDelegate>
-- (void)capturerDidEnd:(RTCVideoCapturer *)capturer;
+- (void)capturerDidEnd:(LKRTCVideoCapturer *)capturer;
 @end
 
 @interface ScreenCaptureController (Private)
@@ -59,7 +59,7 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
 }
 // MARK: CapturerEventsDelegate Methods
 
-- (void)capturerDidEnd:(RTCVideoCapturer *)capturer {
+- (void)capturerDidEnd:(LKRTCVideoCapturer *)capturer {
     [self.eventsDelegate capturerDidEnd:capturer];
 }
 
@@ -67,13 +67,13 @@ NSString *const kRTCAppGroupIdentifier = @"RTCAppGroupIdentifier";
 
 - (NSString *)appGroupIdentifier {
     NSDictionary *infoDictionary = [[NSBundle mainBundle] infoDictionary];
-    return infoDictionary[kRTCAppGroupIdentifier];
+    return infoDictionary[kLKRTCAppGroupIdentifier];
 }
 
 - (NSString *)filePathForApplicationGroupIdentifier:(nonnull NSString *)identifier {
     NSURL *sharedContainer =
         [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:identifier];
-    NSString *socketFilePath = [[sharedContainer URLByAppendingPathComponent:kRTCScreensharingSocketFD] path];
+    NSString *socketFilePath = [[sharedContainer URLByAppendingPathComponent:kLKRTCScreensharingSocketFD] path];
 
     return socketFilePath;
 }

--- a/ios/RCTWebRTC/ScreenCapturePickerViewManager.m
+++ b/ios/RCTWebRTC/ScreenCapturePickerViewManager.m
@@ -5,7 +5,7 @@
 
 #import "ScreenCapturePickerViewManager.h"
 
-NSString *const kRTCScreenSharingExtension = @"RTCScreenSharingExtension";
+NSString *const kLKRTCScreenSharingExtension = @"LKRTCScreenSharingExtension";
 
 @implementation ScreenCapturePickerViewManager {
     RPSystemBroadcastPickerView *_broadcastPickerView;
@@ -26,7 +26,7 @@ RCT_EXPORT_MODULE()
 
 - (NSString *)preferredExtension {
     NSDictionary *infoDictionary = [[NSBundle mainBundle] infoDictionary];
-    return infoDictionary[kRTCScreenSharingExtension];
+    return infoDictionary[kLKRTCScreenSharingExtension];
 }
 
 RCT_EXPORT_METHOD(show : (nonnull NSNumber *)reactTag) {

--- a/ios/RCTWebRTC/ScreenCapturer.h
+++ b/ios/RCTWebRTC/ScreenCapturer.h
@@ -1,16 +1,16 @@
 #import <AVFoundation/AVFoundation.h>
-#import <WebRTC/RTCVideoCapturer.h>
+#import <LiveKitWebRTC/RTCVideoCapturer.h>
 #import "CapturerEventsDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class SocketConnection;
 
-@interface ScreenCapturer : RTCVideoCapturer
+@interface ScreenCapturer : LKRTCVideoCapturer
 
 @property(nonatomic, weak) id<CapturerEventsDelegate> eventsDelegate;
 
-- (instancetype)initWithDelegate:(__weak id<RTCVideoCapturerDelegate>)delegate;
+- (instancetype)initWithDelegate:(__weak id<LKRTCVideoCapturerDelegate>)delegate;
 - (void)startCaptureWithConnection:(nonnull SocketConnection *)connection;
 - (void)stopCapture;
 

--- a/ios/RCTWebRTC/ScreenCapturer.m
+++ b/ios/RCTWebRTC/ScreenCapturer.m
@@ -3,8 +3,8 @@
 #include <mach/mach_time.h>
 
 #import <ReplayKit/ReplayKit.h>
-#import <WebRTC/RTCCVPixelBuffer.h>
-#import <WebRTC/RTCVideoFrameBuffer.h>
+#import <LiveKitWebRTC/RTCCVPixelBuffer.h>
+#import <LiveKitWebRTC/RTCVideoFrameBuffer.h>
 
 #import "ScreenCapturer.h"
 #import "SocketConnection.h"
@@ -136,7 +136,7 @@ const NSUInteger kMaxReadLength = 10 * 1024;
     int64_t _startTimeStampNs;
 }
 
-- (instancetype)initWithDelegate:(__weak id<RTCVideoCapturerDelegate>)delegate {
+- (instancetype)initWithDelegate:(__weak id<LKRTCVideoCapturerDelegate>)delegate {
     self = [super initWithDelegate:delegate];
     if (self) {
         mach_timebase_info(&_timebaseInfo);
@@ -207,26 +207,26 @@ const NSUInteger kMaxReadLength = 10 * 1024;
         _startTimeStampNs = currentTimeStampNs;
     }
 
-    RTCCVPixelBuffer *rtcPixelBuffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
+    LKRTCCVPixelBuffer *rtcPixelBuffer = [[LKRTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
     int64_t frameTimeStampNs = currentTimeStampNs - _startTimeStampNs;
 
-    RTCVideoRotation rotation;
+    LKRTCVideoRotation rotation;
     switch (orientation) {
         case kCGImagePropertyOrientationLeft:
-            rotation = RTCVideoRotation_90;
+            rotation = LKRTCVideoRotation_90;
             break;
         case kCGImagePropertyOrientationDown:
-            rotation = RTCVideoRotation_180;
+            rotation = LKRTCVideoRotation_180;
             break;
         case kCGImagePropertyOrientationRight:
-            rotation = RTCVideoRotation_270;
+            rotation = LKRTCVideoRotation_270;
             break;
         default:
-            rotation = RTCVideoRotation_0;
+            rotation = LKRTCVideoRotation_0;
             break;
     }
 
-    RTCVideoFrame *videoFrame = [[RTCVideoFrame alloc] initWithBuffer:rtcPixelBuffer
+    LKRTCVideoFrame *videoFrame = [[LKRTCVideoFrame alloc] initWithBuffer:rtcPixelBuffer
                                                              rotation:rotation
                                                           timeStampNs:frameTimeStampNs];
 

--- a/ios/RCTWebRTC/SerializeUtils.h
+++ b/ios/RCTWebRTC/SerializeUtils.h
@@ -1,28 +1,28 @@
-#import <WebRTC/RTCMediaStreamTrack.h>
-#import <WebRTC/RTCPeerConnectionFactory.h>
-#import <WebRTC/RTCRtpReceiver.h>
-#import <WebRTC/RTCRtpTransceiver.h>
-#import <WebRTC/RTCVideoCodecInfo.h>
+#import <LiveKitWebRTC/RTCMediaStreamTrack.h>
+#import <LiveKitWebRTC/RTCPeerConnectionFactory.h>
+#import <LiveKitWebRTC/RTCRtpReceiver.h>
+#import <LiveKitWebRTC/RTCRtpTransceiver.h>
+#import <LiveKitWebRTC/RTCVideoCodecInfo.h>
 #import "WebRTCModule+RTCPeerConnection.h"
 
 @interface SerializeUtils : NSObject
 
 + (NSString *_Nonnull)transceiverToJSONWithPeerConnectionId:(nonnull NSNumber *)id
-                                                transceiver:(RTCRtpTransceiver *_Nonnull)transceiver;
-+ (NSDictionary *_Nonnull)senderToJSONWithPeerConnectionId:(nonnull NSNumber *)id sender:(RTCRtpSender *_Nonnull)sender;
+                                                transceiver:(LKRTCRtpTransceiver *_Nonnull)transceiver;
++ (NSDictionary *_Nonnull)senderToJSONWithPeerConnectionId:(nonnull NSNumber *)id sender:(LKRTCRtpSender *_Nonnull)sender;
 + (NSDictionary *_Nonnull)receiverToJSONWithPeerConnectionId:(nonnull NSNumber *)id
-                                                    receiver:(RTCRtpReceiver *_Nonnull)receiver;
+                                                    receiver:(LKRTCRtpReceiver *_Nonnull)receiver;
 + (NSDictionary *_Nonnull)trackToJSONWithPeerConnectionId:(nonnull NSNumber *)id
-                                                    track:(RTCMediaStreamTrack *_Nonnull)track;
-+ (NSDictionary *_Nonnull)capabilitiesToJSON:(RTCRtpCapabilities *_Nonnull)capabilities;
-+ (NSDictionary *_Nonnull)codecCapabilityToJSON:(RTCRtpCodecCapability *_Nonnull)codec;
-+ (NSString *_Nonnull)serializeDirection:(RTCRtpTransceiverDirection)direction;
-+ (RTCRtpTransceiverDirection)parseDirection:(NSString *_Nonnull)direction;
-+ (RTCRtpTransceiverInit *_Nonnull)parseTransceiverOptions:(NSDictionary *_Nonnull)parameters;
-+ (NSDictionary *_Nonnull)parametersToJSON:(RTCRtpParameters *_Nonnull)parameters;
+                                                    track:(LKRTCMediaStreamTrack *_Nonnull)track;
++ (NSDictionary *_Nonnull)capabilitiesToJSON:(LKRTCRtpCapabilities *_Nonnull)capabilities;
++ (NSDictionary *_Nonnull)codecCapabilityToJSON:(LKRTCRtpCodecCapability *_Nonnull)codec;
++ (NSString *_Nonnull)serializeDirection:(LKRTCRtpTransceiverDirection)direction;
++ (LKRTCRtpTransceiverDirection)parseDirection:(NSString *_Nonnull)direction;
++ (LKRTCRtpTransceiverInit *_Nonnull)parseTransceiverOptions:(NSDictionary *_Nonnull)parameters;
++ (NSDictionary *_Nonnull)parametersToJSON:(LKRTCRtpParameters *_Nonnull)parameters;
 + (NSMutableArray *_Nonnull)constructTransceiversInfoArrayWithPeerConnection:
-    (RTCPeerConnection *_Nonnull)peerConnection;
+    (LKRTCPeerConnection *_Nonnull)peerConnection;
 + (NSDictionary *_Nonnull)streamToJSONWithPeerConnectionId:(NSNumber *_Nonnull)id
-                                                    stream:(RTCMediaStream *_Nonnull)stream
+                                                    stream:(LKRTCMediaStream *_Nonnull)stream
                                             streamReactTag:(NSString *_Nonnull)streamReactTag;
 @end

--- a/ios/RCTWebRTC/SerializeUtils.m
+++ b/ios/RCTWebRTC/SerializeUtils.m
@@ -2,7 +2,7 @@
 
 @implementation SerializeUtils
 + (NSDictionary *)transceiverToJSONWithPeerConnectionId:(NSNumber *)id
-                                            transceiver:(RTCRtpTransceiver *_Nonnull)transceiver {
+                                            transceiver:(LKRTCRtpTransceiver *_Nonnull)transceiver {
     NSMutableDictionary *result = [NSMutableDictionary new];
 
     result[@"id"] = transceiver.sender.senderId;
@@ -10,7 +10,7 @@
     result[@"mid"] = transceiver.mid;
     result[@"direction"] = [SerializeUtils serializeDirection:transceiver.direction];
 
-    RTCRtpTransceiverDirection currentDirection;
+    LKRTCRtpTransceiverDirection currentDirection;
     if ([transceiver currentDirection:&currentDirection]) {
         result[@"currentDirection"] = [SerializeUtils serializeDirection:currentDirection];
     }
@@ -22,13 +22,13 @@
     return result;
 }
 
-+ (NSMutableArray *)constructTransceiversInfoArrayWithPeerConnection:(RTCPeerConnection *)peerConnection {
++ (NSMutableArray *)constructTransceiversInfoArrayWithPeerConnection:(LKRTCPeerConnection *)peerConnection {
     NSMutableArray *transceiverUpdates = [NSMutableArray new];
 
-    for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+    for (LKRTCRtpTransceiver *transceiver in peerConnection.transceivers) {
         NSMutableDictionary *transceiverUpdate = [NSMutableDictionary new];
 
-        RTCRtpTransceiverDirection currentDirection;
+        LKRTCRtpTransceiverDirection currentDirection;
         BOOL hasCurrentDirection = [transceiver currentDirection:&currentDirection];
         if (hasCurrentDirection) {
             NSString *currentDirectionSerialized = [SerializeUtils serializeDirection:currentDirection];
@@ -47,7 +47,7 @@
     return transceiverUpdates;
 }
 
-+ (NSDictionary *)senderToJSONWithPeerConnectionId:(NSNumber *)id sender:(RTCRtpSender *)sender {
++ (NSDictionary *)senderToJSONWithPeerConnectionId:(NSNumber *)id sender:(LKRTCRtpSender *)sender {
     NSMutableDictionary *senderDictionary = [NSMutableDictionary new];
     senderDictionary[@"id"] = sender.senderId;
     senderDictionary[@"peerConnectionId"] = id;
@@ -61,7 +61,7 @@
     return senderDictionary;
 }
 
-+ (NSDictionary *)receiverToJSONWithPeerConnectionId:(NSNumber *)id receiver:(RTCRtpReceiver *)receiver {
++ (NSDictionary *)receiverToJSONWithPeerConnectionId:(NSNumber *)id receiver:(LKRTCRtpReceiver *)receiver {
     NSMutableDictionary *receiverDictionary = [NSMutableDictionary new];
     receiverDictionary[@"id"] = receiver.receiverId;
     receiverDictionary[@"peerConnectionId"] = id;
@@ -75,7 +75,7 @@
     return receiverDictionary;
 }
 
-+ (NSDictionary *)parametersToJSON:(RTCRtpParameters *)params {
++ (NSDictionary *)parametersToJSON:(LKRTCRtpParameters *)params {
     NSMutableDictionary *paramsDictionary = [NSMutableDictionary new];
 
     NSMutableDictionary *rtcpDictionary = [NSMutableDictionary new];
@@ -84,7 +84,7 @@
 
     NSMutableArray *headerExtensions = [NSMutableArray new];
 
-    for (RTCRtpHeaderExtension *extension in params.headerExtensions) {
+    for (LKRTCRtpHeaderExtension *extension in params.headerExtensions) {
         NSMutableDictionary *extensionDictionary = [NSMutableDictionary new];
         extensionDictionary[@"id"] = [NSNumber numberWithInt:extension.id];
         extensionDictionary[@"uri"] = extension.uri;
@@ -95,7 +95,7 @@
 
     NSMutableArray *encodings = [NSMutableArray new];
 
-    for (RTCRtpEncodingParameters *encoding in params.encodings) {
+    for (LKRTCRtpEncodingParameters *encoding in params.encodings) {
         NSMutableDictionary *encodingDictionary = [NSMutableDictionary new];
 
         encodingDictionary[@"active"] = [NSNumber numberWithBool:encoding.isActive];
@@ -121,7 +121,7 @@
 
     NSMutableArray *codecs = [NSMutableArray new];
 
-    for (RTCRtpCodecParameters *codec in params.codecs) {
+    for (LKRTCRtpCodecParameters *codec in params.codecs) {
         NSMutableDictionary *codecDictionary = [NSMutableDictionary new];
 
         codecDictionary[@"payloadType"] = [NSNumber numberWithInt:codec.payloadType];
@@ -152,13 +152,13 @@
     return paramsDictionary;
 }
 
-+ (NSDictionary *)trackToJSONWithPeerConnectionId:(NSNumber *)id track:(RTCMediaStreamTrack *)track {
++ (NSDictionary *)trackToJSONWithPeerConnectionId:(NSNumber *)id track:(LKRTCMediaStreamTrack *)track {
     NSString *readyState;
     switch (track.readyState) {
-        case RTCMediaStreamTrackStateLive:
+        case LKRTCMediaStreamTrackStateLive:
             readyState = @"live";
             break;
-        case RTCMediaStreamTrackStateEnded:
+        case LKRTCMediaStreamTrackStateEnded:
             readyState = @"ended";
             break;
     }
@@ -173,17 +173,17 @@
     };
 }
 
-+ (NSDictionary *)capabilitiesToJSON:(RTCRtpCapabilities *)capabilities {
++ (NSDictionary *)capabilitiesToJSON:(LKRTCRtpCapabilities *)capabilities {
     NSMutableArray *codecs = [NSMutableArray new];
 
-    for (RTCRtpCodecCapability *codec in capabilities.codecs) {
+    for (LKRTCRtpCodecCapability *codec in capabilities.codecs) {
         [codecs addObject:[self codecCapabilityToJSON:codec]];
     }
 
     return @{@"codecs" : codecs};
 }
 
-+ (NSDictionary *)codecCapabilityToJSON:(RTCRtpCodecCapability *)codec {
++ (NSDictionary *)codecCapabilityToJSON:(LKRTCRtpCodecCapability *)codec {
     NSMutableDictionary *codecDictionary = [NSMutableDictionary new];
 
     codecDictionary[@"payloadType"] = codec.preferredPayloadType;
@@ -214,39 +214,39 @@
     return [parts componentsJoinedByString:@";"];
 }
 
-+ (NSString *)serializeDirection:(RTCRtpTransceiverDirection)direction {
-    if (direction == RTCRtpTransceiverDirectionInactive) {
++ (NSString *)serializeDirection:(LKRTCRtpTransceiverDirection)direction {
+    if (direction == LKRTCRtpTransceiverDirectionInactive) {
         return @"inactive";
-    } else if (direction == RTCRtpTransceiverDirectionRecvOnly) {
+    } else if (direction == LKRTCRtpTransceiverDirectionRecvOnly) {
         return @"recvonly";
-    } else if (direction == RTCRtpTransceiverDirectionSendOnly) {
+    } else if (direction == LKRTCRtpTransceiverDirectionSendOnly) {
         return @"sendonly";
-    } else if (direction == RTCRtpTransceiverDirectionSendRecv) {
+    } else if (direction == LKRTCRtpTransceiverDirectionSendRecv) {
         return @"sendrecv";
-    } else if (direction == RTCRtpTransceiverDirectionStopped) {
+    } else if (direction == LKRTCRtpTransceiverDirectionStopped) {
         return @"stopped";
     }
     return nil;
 }
 
-+ (RTCRtpTransceiverDirection)parseDirection:(NSString *)direction {
++ (LKRTCRtpTransceiverDirection)parseDirection:(NSString *)direction {
     if ([direction isEqual:@"inactive"]) {
-        return RTCRtpTransceiverDirectionInactive;
+        return LKRTCRtpTransceiverDirectionInactive;
     } else if ([direction isEqual:@"recvonly"]) {
-        return RTCRtpTransceiverDirectionRecvOnly;
+        return LKRTCRtpTransceiverDirectionRecvOnly;
     } else if ([direction isEqual:@"sendonly"]) {
-        return RTCRtpTransceiverDirectionSendOnly;
+        return LKRTCRtpTransceiverDirectionSendOnly;
     } else if ([direction isEqual:@"sendrecv"]) {
-        return RTCRtpTransceiverDirectionSendRecv;
+        return LKRTCRtpTransceiverDirectionSendRecv;
     } else if ([direction isEqual:@"stopped"]) {
-        return RTCRtpTransceiverDirectionStopped;
+        return LKRTCRtpTransceiverDirectionStopped;
     }
 
-    return RTCRtpTransceiverDirectionInactive;
+    return LKRTCRtpTransceiverDirectionInactive;
 }
 
-+ (RTCRtpEncodingParameters *)parseEncoding:(NSDictionary *)params {
-    RTCRtpEncodingParameters *encoding = [RTCRtpEncodingParameters new];
++ (LKRTCRtpEncodingParameters *)parseEncoding:(NSDictionary *)params {
+    LKRTCRtpEncodingParameters *encoding = [LKRTCRtpEncodingParameters new];
 
     if (params[@"rid"] != nil) {
         [encoding setRid:params[@"rid"]];
@@ -270,8 +270,8 @@
     return encoding;
 }
 
-+ (RTCRtpTransceiverInit *)parseTransceiverOptions:(NSDictionary *)params {
-    RTCRtpTransceiverInit *transceiverInit = [RTCRtpTransceiverInit new];
++ (LKRTCRtpTransceiverInit *)parseTransceiverOptions:(NSDictionary *)params {
+    LKRTCRtpTransceiverInit *transceiverInit = [LKRTCRtpTransceiverInit new];
 
     NSString *direction = [params objectForKey:@"direction"];
     if (direction) {
@@ -285,7 +285,7 @@
 
     NSArray *encodingsArray = [params objectForKey:@"sendEncodings"];
     if (encodingsArray) {
-        NSMutableArray<RTCRtpEncodingParameters *> *sendEncodings = [NSMutableArray new];
+        NSMutableArray<LKRTCRtpEncodingParameters *> *sendEncodings = [NSMutableArray new];
         for (NSDictionary *encoding in encodingsArray) {
             [sendEncodings addObject:[self parseEncoding:encoding]];
         }
@@ -296,7 +296,7 @@
 }
 
 + (NSDictionary *)streamToJSONWithPeerConnectionId:(NSNumber *)id
-                                            stream:(RTCMediaStream *)stream
+                                            stream:(LKRTCMediaStream *)stream
                                     streamReactTag:(NSString *)streamReactTag {
     NSMutableDictionary *streamDictionary = [NSMutableDictionary new];
 
@@ -305,11 +305,11 @@
 
     NSMutableArray *tracks = [NSMutableArray new];
 
-    for (RTCAudioTrack *audioTrack in stream.audioTracks) {
+    for (LKRTCAudioTrack *audioTrack in stream.audioTracks) {
         [tracks addObject:[SerializeUtils trackToJSONWithPeerConnectionId:id track:audioTrack]];
     }
 
-    for (RTCVideoTrack *videoTrack in stream.videoTracks) {
+    for (LKRTCVideoTrack *videoTrack in stream.videoTracks) {
         [tracks addObject:[SerializeUtils trackToJSONWithPeerConnectionId:id track:videoTrack]];
     }
 

--- a/ios/RCTWebRTC/TrackCapturerEventsEmitter.h
+++ b/ios/RCTWebRTC/TrackCapturerEventsEmitter.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWith:(NSString *)trackId webRTCModule:(WebRTCModule *)module;
 
-- (void)capturerDidEnd:(RTCVideoCapturer *)capturer;
+- (void)capturerDidEnd:(LKRTCVideoCapturer *)capturer;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/RCTWebRTC/TrackCapturerEventsEmitter.m
+++ b/ios/RCTWebRTC/TrackCapturerEventsEmitter.m
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)capturerDidEnd:(RTCVideoCapturer *)capturer {
+- (void)capturerDidEnd:(LKRTCVideoCapturer *)capturer {
     [self.module sendEventWithName:kEventMediaStreamTrackEnded
                               body:@{
                                   @"trackId" : self.trackId,

--- a/ios/RCTWebRTC/VideoCaptureController.h
+++ b/ios/RCTWebRTC/VideoCaptureController.h
@@ -1,17 +1,17 @@
 #if !TARGET_OS_TV
 
 #import <Foundation/Foundation.h>
-#import <WebRTC/RTCCameraVideoCapturer.h>
+#import <LiveKitWebRTC/RTCCameraVideoCapturer.h>
 
 #import "CaptureController.h"
 
 @interface VideoCaptureController : CaptureController
-@property(nonatomic, readonly, strong) RTCCameraVideoCapturer *capturer;
+@property(nonatomic, readonly, strong) LKRTCCameraVideoCapturer *capturer;
 @property(nonatomic, readonly, strong) AVCaptureDeviceFormat *selectedFormat;
 @property(nonatomic, readonly, assign) int frameRate;
 @property(nonatomic, assign) BOOL enableMultitaskingCameraAccess;
 
-- (instancetype)initWithCapturer:(RTCCameraVideoCapturer *)capturer andConstraints:(NSDictionary *)constraints;
+- (instancetype)initWithCapturer:(LKRTCCameraVideoCapturer *)capturer andConstraints:(NSDictionary *)constraints;
 - (void)startCapture;
 - (void)stopCapture;
 - (void)switchCamera;

--- a/ios/RCTWebRTC/VideoCaptureController.m
+++ b/ios/RCTWebRTC/VideoCaptureController.m
@@ -6,7 +6,7 @@
 
 @interface VideoCaptureController ()
 
-@property(nonatomic, strong) RTCCameraVideoCapturer *capturer;
+@property(nonatomic, strong) LKRTCCameraVideoCapturer *capturer;
 @property(nonatomic, strong) AVCaptureDeviceFormat *selectedFormat;
 @property(nonatomic, strong) AVCaptureDevice *device;
 @property(nonatomic, assign) BOOL running;
@@ -19,7 +19,7 @@
 
 @implementation VideoCaptureController
 
-- (instancetype)initWithCapturer:(RTCCameraVideoCapturer *)capturer andConstraints:(NSDictionary *)constraints {
+- (instancetype)initWithCapturer:(LKRTCCameraVideoCapturer *)capturer andConstraints:(NSDictionary *)constraints {
     self = [super init];
     if (self) {
         self.capturer = capturer;
@@ -254,7 +254,7 @@
 }
 
 - (AVCaptureDevice *)findDeviceForPosition:(AVCaptureDevicePosition)position {
-    NSArray<AVCaptureDevice *> *captureDevices = [RTCCameraVideoCapturer captureDevices];
+    NSArray<AVCaptureDevice *> *captureDevices = [LKRTCCameraVideoCapturer captureDevices];
     for (AVCaptureDevice *device in captureDevices) {
         if (device.position == position) {
             return device;
@@ -267,7 +267,7 @@
 - (AVCaptureDeviceFormat *)selectFormatForDevice:(AVCaptureDevice *)device
                                  withTargetWidth:(int)targetWidth
                                 withTargetHeight:(int)targetHeight {
-    NSArray<AVCaptureDeviceFormat *> *formats = [RTCCameraVideoCapturer supportedFormatsForDevice:device];
+    NSArray<AVCaptureDeviceFormat *> *formats = [LKRTCCameraVideoCapturer supportedFormatsForDevice:device];
     AVCaptureDeviceFormat *selectedFormat = nil;
     int currentDiff = INT_MAX;
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.h
@@ -1,5 +1,5 @@
 #import "WebRTCModule.h"
 
-@interface WebRTCModule (RTCAudioDeviceModule)
+@interface WebRTCModule (LKRTCAudioDeviceModule)
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.m
@@ -6,7 +6,7 @@
 #import "AudioDeviceModuleObserver.h"
 #import "WebRTCModule.h"
 
-@implementation WebRTCModule (RTCAudioDeviceModule)
+@implementation WebRTCModule (LKRTCAudioDeviceModule)
 
 #pragma mark - Recording & Playback Control
 
@@ -154,7 +154,7 @@ RCT_EXPORT_METHOD(audioDeviceModuleSetMuteMode
                   : (NSInteger)mode resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    NSInteger result = [self.audioDeviceModule setMuteMode:(RTCAudioEngineMuteMode)mode];
+    NSInteger result = [self.audioDeviceModule setMuteMode:(LKRTCAudioEngineMuteMode)mode];
     if (result == 0) {
         resolve(nil);
     } else {
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(audioDeviceModuleSetRecordingAlwaysPreparedMode
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleGetEngineAvailability) {
-    RTCAudioEngineAvailability availability = self.audioDeviceModule.engineAvailability;
+    LKRTCAudioEngineAvailability availability = self.audioDeviceModule.engineAvailability;
     return @{
         @"isInputAvailable" : @(availability.isInputAvailable),
         @"isOutputAvailable" : @(availability.isOutputAvailable)
@@ -214,7 +214,7 @@ RCT_EXPORT_METHOD(audioDeviceModuleSetEngineAvailability
                   : (NSDictionary *)availabilityDict resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCAudioEngineAvailability availability;
+    LKRTCAudioEngineAvailability availability;
     availability.isInputAvailable = [availabilityDict[@"isInputAvailable"] boolValue];
     availability.isOutputAvailable = [availabilityDict[@"isOutputAvailable"] boolValue];
     NSInteger result = [self.audioDeviceModule setEngineAvailability:availability];

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioSession.m
@@ -5,15 +5,15 @@
 
 #import "WebRTCModule.h"
 
-@implementation WebRTCModule (RTCAudioSession)
+@implementation WebRTCModule (LKRTCAudioSession)
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioSessionDidActivate) {
-    [[RTCAudioSession sharedInstance] audioSessionDidActivate:[AVAudioSession sharedInstance]];
+    [[LKRTCAudioSession sharedInstance] audioSessionDidActivate:[AVAudioSession sharedInstance]];
     return nil;
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioSessionDidDeactivate) {
-    [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:[AVAudioSession sharedInstance]];
+    [[LKRTCAudioSession sharedInstance] audioSessionDidDeactivate:[AVAudioSession sharedInstance]];
     return nil;
 }
 

--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.h
@@ -1,14 +1,14 @@
 #import "DataChannelWrapper.h"
 #import "WebRTCModule.h"
 
-@interface RTCDataChannel (React)
+@interface LKRTCDataChannel (React)
 
 @property(nonatomic, strong) NSNumber *peerConnectionId;
 
 @end
 
-@interface WebRTCModule (RTCDataChannel)<DataChannelWrapperDelegate>
+@interface WebRTCModule (LKRTCDataChannel)<DataChannelWrapperDelegate>
 
-- (NSString *)stringForDataChannelState:(RTCDataChannelState)state;
+- (NSString *)stringForDataChannelState:(LKRTCDataChannelState)state;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCDataChannel.m
@@ -4,11 +4,11 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 
-#import <WebRTC/RTCDataChannelConfiguration.h>
+#import <LiveKitWebRTC/RTCDataChannelConfiguration.h>
 #import "WebRTCModule+RTCDataChannel.h"
 #import "WebRTCModule+RTCPeerConnection.h"
 
-@implementation WebRTCModule (RTCDataChannel)
+@implementation WebRTCModule (LKRTCDataChannel)
 
 /*
  * Thuis methos is implemented synchronously since we need to create the DataChannel on the spot
@@ -17,11 +17,11 @@
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(createDataChannel
                                        : (nonnull NSNumber *)peerConnectionId label
                                        : (NSString *)label config
-                                       : (RTCDataChannelConfiguration *)config) {
+                                       : (LKRTCDataChannelConfiguration *)config) {
     __block id channelInfo;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+        LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
 
         if (peerConnection == nil) {
             RCTLogWarn(@"PeerConnection %@ not found", peerConnectionId);
@@ -29,7 +29,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(createDataChannel
             return;
         }
 
-        RTCDataChannel *dataChannel = [peerConnection dataChannelForLabel:label configuration:config];
+        LKRTCDataChannel *dataChannel = [peerConnection dataChannelForLabel:label configuration:config];
 
         if (dataChannel == nil) {
             channelInfo = nil;
@@ -62,7 +62,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(createDataChannel
 RCT_EXPORT_METHOD(dataChannelClose
                   : (nonnull NSNumber *)peerConnectionId reactTag
                   : (nonnull NSString *)tag {
-                      RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+                      LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
                       DataChannelWrapper *dcw = peerConnection.dataChannels[tag];
                       if (dcw) {
                           [dcw.channel close];
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(dataChannelClose
 RCT_EXPORT_METHOD(dataChannelDispose
                   : (nonnull NSNumber *)peerConnectionId reactTag
                   : (nonnull NSString *)tag {
-                      RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+                      LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
                       DataChannelWrapper *dcw = peerConnection.dataChannels[tag];
                       if (dcw) {
                           dcw.delegate = nil;
@@ -85,26 +85,26 @@ RCT_EXPORT_METHOD(dataChannelSend
                   : (nonnull NSString *)tag data
                   : (NSString *)data type
                   : (NSString *)type {
-                      RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+                      LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
                       DataChannelWrapper *dcw = peerConnection.dataChannels[tag];
                       if (dcw) {
                           BOOL isBinary = [type isEqualToString:@"binary"];
                           NSData *bytes = isBinary ? [[NSData alloc] initWithBase64EncodedString:data options:0]
                                                    : [data dataUsingEncoding:NSUTF8StringEncoding];
-                          RTCDataBuffer *buffer = [[RTCDataBuffer alloc] initWithData:bytes isBinary:isBinary];
+                          LKRTCDataBuffer *buffer = [[LKRTCDataBuffer alloc] initWithData:bytes isBinary:isBinary];
                           [dcw.channel sendData:buffer];
                       }
                   })
 
-- (NSString *)stringForDataChannelState:(RTCDataChannelState)state {
+- (NSString *)stringForDataChannelState:(LKRTCDataChannelState)state {
     switch (state) {
-        case RTCDataChannelStateConnecting:
+        case LKRTCDataChannelStateConnecting:
             return @"connecting";
-        case RTCDataChannelStateOpen:
+        case LKRTCDataChannelStateOpen:
             return @"open";
-        case RTCDataChannelStateClosing:
+        case LKRTCDataChannelStateClosing:
             return @"closing";
-        case RTCDataChannelStateClosed:
+        case LKRTCDataChannelStateClosed:
             return @"closed";
     }
     return nil;
@@ -114,7 +114,7 @@ RCT_EXPORT_METHOD(dataChannelSend
 
 // Called when the data channel state has changed.
 - (void)dataChannelDidChangeState:(DataChannelWrapper *)dcw {
-    RTCDataChannel *channel = dcw.channel;
+    LKRTCDataChannel *channel = dcw.channel;
     NSDictionary *event = @{
         @"reactTag" : dcw.reactTag,
         @"peerConnectionId" : dcw.pcId,
@@ -125,7 +125,7 @@ RCT_EXPORT_METHOD(dataChannelSend
 }
 
 // Called when a data buffer was successfully received.
-- (void)dataChannel:(DataChannelWrapper *)dcw didReceiveMessageWithBuffer:(RTCDataBuffer *)buffer {
+- (void)dataChannel:(DataChannelWrapper *)dcw didReceiveMessageWithBuffer:(LKRTCDataBuffer *)buffer {
     NSString *type;
     NSString *data;
     if (buffer.isBinary) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCFrameCryptor.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCFrameCryptor.m
@@ -10,30 +10,30 @@
 // Key for objc_set/getAssociatedObject, value of NSString*
 static char frameCryptorUUIDKey;
 
-@interface WebRTCModule ()<RTCFrameCryptorDelegate>
+@interface WebRTCModule ()<LKRTCFrameCryptorDelegate>
 @end
 
-@implementation WebRTCModule (RTCFrameCryptor)
+@implementation WebRTCModule (LKRTCFrameCryptor)
 
-- (RTCCryptorAlgorithm)getAlgorithm:(NSNumber *)algorithm {
+- (LKRTCCryptorAlgorithm)getAlgorithm:(NSNumber *)algorithm {
     switch ([algorithm intValue]) {
         // case 0:
-        //     return RTCCryptorAlgorithmAesGcm;
+        //     return LKRTCCryptorAlgorithmAesGcm;
         // case 1:
-        //     return RTCCryptorAlgorithmAesCbc;
+        //     return LKRTCCryptorAlgorithmAesCbc;
         default:
-            return RTCCryptorAlgorithmAesGcm;
+            return LKRTCCryptorAlgorithmAesGcm;
     }
 }
 
-- (RTCKeyDerivationAlgorithm)getKeyDerivationAlgorithm:(NSNumber *)algorithm {
+- (LKRTCKeyDerivationAlgorithm)getKeyDerivationAlgorithm:(NSNumber *)algorithm {
     switch ([algorithm intValue]) {
         case 0:
-            return RTCKeyDerivationAlgorithmPBKDF2;
+            return LKRTCKeyDerivationAlgorithmPBKDF2;
         case 1:
-            return RTCKeyDerivationAlgorithmHKDF;
+            return LKRTCKeyDerivationAlgorithmHKDF;
         default:
-            return RTCKeyDerivationAlgorithmPBKDF2;
+            return LKRTCKeyDerivationAlgorithmPBKDF2;
     }
 }
 
@@ -72,7 +72,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(frameCryptorFactoryCreateFrameCryptor : (
             return;
         }
 
-        RTCFrameCryptorKeyProvider *keyProvider = self.keyProviders[keyProviderId];
+        LKRTCFrameCryptorKeyProvider *keyProvider = self.keyProviders[keyProviderId];
         if (keyProvider == nil) {
             NSLog(@"frameCryptorFactoryCreateFrameCryptorFailed: Invalid keyProvider");
             return;
@@ -83,14 +83,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(frameCryptorFactoryCreateFrameCryptor : (
         NSString *rtpReceiverId = constraints[@"rtpReceiverId"];
 
         if ([type isEqualToString:@"sender"]) {
-            RTCRtpSender *sender = [self getSenderByPeerConnectionId:peerConnectionId senderId:rtpSenderId];
+            LKRTCRtpSender *sender = [self getSenderByPeerConnectionId:peerConnectionId senderId:rtpSenderId];
 
             if (sender == nil) {
                 NSLog(@"frameCryptorFactoryCreateFrameCryptorFailed: Error: sender not found!");
                 return;
             }
 
-            RTCFrameCryptor *frameCryptor = [[RTCFrameCryptor alloc] initWithFactory:self.peerConnectionFactory
+            LKRTCFrameCryptor *frameCryptor = [[LKRTCFrameCryptor alloc] initWithFactory:self.peerConnectionFactory
                                                                            rtpSender:sender
                                                                        participantId:participantId
                                                                            algorithm:[self getAlgorithm:algorithm]
@@ -103,12 +103,12 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(frameCryptorFactoryCreateFrameCryptor : (
             objc_setAssociatedObject(frameCryptor, &frameCryptorUUIDKey, frameCryptorId, OBJC_ASSOCIATION_COPY);
             return;
         } else if ([type isEqualToString:@"receiver"]) {
-            RTCRtpReceiver *receiver = [self getReceiverByPeerConnectionId:peerConnectionId receiverId:rtpReceiverId];
+            LKRTCRtpReceiver *receiver = [self getReceiverByPeerConnectionId:peerConnectionId receiverId:rtpReceiverId];
             if (receiver == nil) {
                 NSLog(@"frameCryptorFactoryCreateFrameCryptorFailed: Error: receiver not found!");
                 return;
             }
-            RTCFrameCryptor *frameCryptor = [[RTCFrameCryptor alloc] initWithFactory:self.peerConnectionFactory
+            LKRTCFrameCryptor *frameCryptor = [[LKRTCFrameCryptor alloc] initWithFactory:self.peerConnectionFactory
                                                                          rtpReceiver:receiver
                                                                        participantId:participantId
                                                                            algorithm:[self getAlgorithm:algorithm]
@@ -138,7 +138,7 @@ RCT_EXPORT_METHOD(frameCryptorSetKeyIndex
         reject(@"frameCryptorSetKeyIndexFailed", @"Invalid frameCryptorId", nil);
         return;
     }
-    RTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
+    LKRTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
     if (frameCryptor == nil) {
         reject(@"frameCryptorSetKeyIndexFailed", @"Invalid frameCryptor", nil);
         return;
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(frameCryptorGetKeyIndex
         reject(@"frameCryptorGetKeyIndexFailed", @"Invalid frameCryptorId", nil);
         return;
     }
-    RTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
+    LKRTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
     if (frameCryptor == nil) {
         reject(@"frameCryptorGetKeyIndexFailed", @"Invalid frameCryptor", nil);
         return;
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(frameCryptorSetEnabled
         reject(@"frameCryptorSetEnabledFailed", @"Invalid frameCryptorId", nil);
         return;
     }
-    RTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
+    LKRTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
     if (frameCryptor == nil) {
         reject(@"frameCryptorSetEnabledFailed", @"Invalid frameCryptor", nil);
         return;
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(frameCryptorGetEnabled
         reject(@"frameCryptorGetEnabledFailed", @"Invalid frameCryptorId", nil);
         return;
     }
-    RTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
+    LKRTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
     if (frameCryptor == nil) {
         reject(@"frameCryptorGetEnabledFailed", @"Invalid frameCryptor", nil);
         return;
@@ -220,7 +220,7 @@ RCT_EXPORT_METHOD(frameCryptorDispose
         reject(@"frameCryptorDisposeFailed", @"Invalid frameCryptorId", nil);
         return;
     }
-    RTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
+    LKRTCFrameCryptor *frameCryptor = self.frameCryptors[frameCryptorId];
     if (frameCryptor == nil) {
         reject(@"frameCryptorDisposeFailed", @"Invalid frameCryptor", nil);
         return;
@@ -270,7 +270,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(frameCryptorFactoryCreateKeyProvider
         NSNumber *discardFrameWhenCryptorNotReady = keyProviderOptions[@"discardFrameWhenCryptorNotReady"];
         NSNumber *keyDerivationAlgorithm = keyProviderOptions[@"keyDerivationAlgorithm"];
 
-        RTCFrameCryptorKeyProvider *keyProvider = [[RTCFrameCryptorKeyProvider alloc]
+        LKRTCFrameCryptorKeyProvider *keyProvider = [[LKRTCFrameCryptorKeyProvider alloc]
                         initWithRatchetSalt:ratchetSalt
                           ratchetWindowSize:[ratchetWindowSize intValue]
                               sharedKeyMode:[sharedKey boolValue]
@@ -287,13 +287,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(frameCryptorFactoryCreateKeyProvider
     return keyProviderId;
 }
 
-- (nullable RTCFrameCryptorKeyProvider *)getKeyProviderForId:(NSString *)keyProviderId
+- (nullable LKRTCFrameCryptorKeyProvider *)getKeyProviderForId:(NSString *)keyProviderId
                                                     rejecter:(RCTPromiseRejectBlock)reject {
     if (keyProviderId == nil) {
         reject(@"getKeyProviderForIdFailed", @"Invalid keyProviderId", nil);
         return nil;
     }
-    RTCFrameCryptorKeyProvider *keyProvider = self.keyProviders[keyProviderId];
+    LKRTCFrameCryptorKeyProvider *keyProvider = self.keyProviders[keyProviderId];
     if (keyProvider == nil) {
         reject(@"getKeyProviderForIdFailed", @"Invalid keyProvider", nil);
         return nil;
@@ -305,7 +305,7 @@ RCT_EXPORT_METHOD(keyProviderSetSharedKey
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -330,7 +330,7 @@ RCT_EXPORT_METHOD(keyProviderRatchetSharedKey
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -349,7 +349,7 @@ RCT_EXPORT_METHOD(keyProviderExportSharedKey
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -368,7 +368,7 @@ RCT_EXPORT_METHOD(keyProviderSetKey
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -399,7 +399,7 @@ RCT_EXPORT_METHOD(keyProviderRatchetKey
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -424,7 +424,7 @@ RCT_EXPORT_METHOD(keyProviderExportKey
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -449,7 +449,7 @@ RCT_EXPORT_METHOD(keyProviderSetSifTrailer
                   : (nonnull NSDictionary *)constraints resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
+    LKRTCFrameCryptorKeyProvider *keyProvider = [self getKeyProviderForId:constraints[@"keyProviderId"] rejecter:reject];
     if (keyProvider == nil) {
         return;
     }
@@ -477,21 +477,21 @@ RCT_EXPORT_METHOD(keyProviderDispose
     resolve(@{@"result" : @"success"});
 }
 
-- (NSString *)stringFromState:(RTCFrameCryptorState)state {
+- (NSString *)stringFromState:(LKRTCFrameCryptorState)state {
     switch (state) {
-        case RTCFrameCryptorStateNew:
+        case LKRTCFrameCryptorStateNew:
             return @"new";
-        case RTCFrameCryptorStateOk:
+        case LKRTCFrameCryptorStateOk:
             return @"ok";
-        case RTCFrameCryptorStateEncryptionFailed:
+        case LKRTCFrameCryptorStateEncryptionFailed:
             return @"encryptionFailed";
-        case RTCFrameCryptorStateDecryptionFailed:
+        case LKRTCFrameCryptorStateDecryptionFailed:
             return @"decryptionFailed";
-        case RTCFrameCryptorStateMissingKey:
+        case LKRTCFrameCryptorStateMissingKey:
             return @"missingKey";
-        case RTCFrameCryptorStateKeyRatcheted:
+        case LKRTCFrameCryptorStateKeyRatcheted:
             return @"keyRatcheted";
-        case RTCFrameCryptorStateInternalError:
+        case LKRTCFrameCryptorStateInternalError:
             return @"internalError";
         default:
             return @"unknown";
@@ -509,13 +509,13 @@ RCT_EXPORT_METHOD(dataPacketCryptorFactoryCreateDataPacketCryptor
         return;
     }
 
-    RTCFrameCryptorKeyProvider *keyProvider = self.keyProviders[keyProviderId];
+    LKRTCFrameCryptorKeyProvider *keyProvider = self.keyProviders[keyProviderId];
     if (keyProvider == nil) {
         reject(@"getKeyProviderForIdFailed", @"Invalid keyProviderId", nil);
         return;
     }
 
-    RTCDataPacketCryptor *cryptor = [[RTCDataPacketCryptor alloc] initWithAlgorithm:[self getAlgorithm:algorithm]
+    LKRTCDataPacketCryptor *cryptor = [[LKRTCDataPacketCryptor alloc] initWithAlgorithm:[self getAlgorithm:algorithm]
                                                                         keyProvider:keyProvider];
     NSString *cryptorId = [[NSUUID UUID] UUIDString];
 
@@ -533,14 +533,14 @@ RCT_EXPORT_METHOD(dataPacketCryptorEncrypt
     NSNumber *keyIndex = constraints[@"keyIndex"];
     NSData *data = [self bytesFromMap:constraints key:@"data" isBase64Key:nil];
 
-    RTCDataPacketCryptor *cryptor = self.dataPacketCryptors[cryptorId];
+    LKRTCDataPacketCryptor *cryptor = self.dataPacketCryptors[cryptorId];
 
     if (cryptor == nil) {
         reject(@"dataPacketCryptorEncryptFailed", @"data packet cryptor not found", nil);
         return;
     }
 
-    RTCEncryptedPacket *packet = [cryptor encrypt:participantId keyIndex:[keyIndex unsignedIntValue] data:data];
+    LKRTCEncryptedPacket *packet = [cryptor encrypt:participantId keyIndex:[keyIndex unsignedIntValue] data:data];
 
     if (packet == nil) {
         reject(@"dataPacketCryptorEncryptFailed", @"packet encryption failed", nil);
@@ -564,14 +564,14 @@ RCT_EXPORT_METHOD(dataPacketCryptorDecrypt
     NSData *payload = [self bytesFromMap:constraints key:@"payload" isBase64Key:nil];
     NSData *iv = [self bytesFromMap:constraints key:@"iv" isBase64Key:nil];
 
-    RTCDataPacketCryptor *cryptor = self.dataPacketCryptors[cryptorId];
+    LKRTCDataPacketCryptor *cryptor = self.dataPacketCryptors[cryptorId];
 
     if (cryptor == nil) {
         reject(@"dataPacketCryptorDecryptFailed", @"data packet cryptor not found", nil);
         return;
     }
 
-    RTCEncryptedPacket *packet = [[RTCEncryptedPacket alloc] initWithData:payload
+    LKRTCEncryptedPacket *packet = [[LKRTCEncryptedPacket alloc] initWithData:payload
                                                                        iv:iv
                                                                  keyIndex:[keyIndex unsignedIntValue]];
     NSData *decryptedData = [cryptor decrypt:participantId encryptedPacket:packet];
@@ -589,7 +589,7 @@ RCT_EXPORT_METHOD(dataPacketCryptorDispose
                   : (RCTPromiseRejectBlock)reject) {
     NSString *cryptorId = constraints[@"dataPacketCryptorId"];
 
-    RTCDataPacketCryptor *cryptor = self.dataPacketCryptors[cryptorId];
+    LKRTCDataPacketCryptor *cryptor = self.dataPacketCryptors[cryptorId];
 
     if (cryptor == nil) {
         reject(@"dataPacketCryptorDisposeFailed", @"data packet cryptor not found", nil);
@@ -600,11 +600,11 @@ RCT_EXPORT_METHOD(dataPacketCryptorDispose
     resolve(@{@"result" : @"success"});
 }
 
-#pragma mark - RTCFrameCryptorDelegate methods
+#pragma mark - LKRTCFrameCryptorDelegate methods
 
-- (void)frameCryptor:(RTC_OBJC_TYPE(RTCFrameCryptor) *)frameCryptor
+- (void)frameCryptor:(RTC_OBJC_TYPE(LKRTCFrameCryptor) *)frameCryptor
     didStateChangeWithParticipantId:(NSString *)participantId
-                          withState:(RTCFrameCryptorState)stateChanged {
+                          withState:(LKRTCFrameCryptorState)stateChanged {
     id frameCryptorId = objc_getAssociatedObject(frameCryptor, &frameCryptorUUIDKey);
 
     if (![frameCryptorId isKindOfClass:[NSString class]]) {

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.h
@@ -2,13 +2,13 @@
 #import "VideoEffectProcessor.h"
 #import "WebRTCModule.h"
 
-@interface WebRTCModule (RTCMediaStream)
+@interface WebRTCModule (LKRTCMediaStream)
 
 @property(nonatomic, strong) VideoEffectProcessor *videoEffectProcessor;
 
-- (RTCVideoTrack *)createVideoTrackWithCaptureController:
-    (CaptureController * (^)(RTCVideoSource *))captureControllerCreator;
-- (NSArray *)createMediaStream:(NSArray<RTCMediaStreamTrack *> *)tracks;
+- (LKRTCVideoTrack *)createVideoTrackWithCaptureController:
+    (CaptureController * (^)(LKRTCVideoSource *))captureControllerCreator;
+- (NSArray *)createMediaStream:(NSArray<LKRTCMediaStreamTrack *> *)tracks;
 
-- (RTCMediaStreamTrack *)trackForId:(nonnull NSString *)trackId pcId:(nonnull NSNumber *)pcId;
+- (LKRTCMediaStreamTrack *)trackForId:(nonnull NSString *)trackId pcId:(nonnull NSNumber *)pcId;
 @end

--- a/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCMediaStream.m
@@ -1,9 +1,9 @@
 #import <objc/runtime.h>
 
-#import <WebRTC/RTCCameraVideoCapturer.h>
-#import <WebRTC/RTCMediaConstraints.h>
-#import <WebRTC/RTCMediaStreamTrack.h>
-#import <WebRTC/RTCVideoTrack.h>
+#import <LiveKitWebRTC/RTCCameraVideoCapturer.h>
+#import <LiveKitWebRTC/RTCMediaConstraints.h>
+#import <LiveKitWebRTC/RTCMediaStreamTrack.h>
+#import <LiveKitWebRTC/RTCVideoTrack.h>
 
 #import "RTCMediaStreamTrack+React.h"
 #import "WebRTCModule+RTCMediaStream.h"
@@ -16,7 +16,7 @@
 #import "TrackCapturerEventsEmitter.h"
 #import "VideoCaptureController.h"
 
-@implementation WebRTCModule (RTCMediaStream)
+@implementation WebRTCModule (LKRTCMediaStream)
 
 - (VideoEffectProcessor *)videoEffectProcessor {
     return objc_getAssociatedObject(self, _cmd);
@@ -34,12 +34,12 @@
 }
 
 /**
- * Initializes a new {@link RTCAudioTrack} which satisfies the given constraints.
+ * Initializes a new {@link LKRTCAudioTrack} which satisfies the given constraints.
  *
  * @param constraints The {@code MediaStreamConstraints} which the new
- * {@code RTCAudioTrack} instance is to satisfy.
+ * {@code LKRTCAudioTrack} instance is to satisfy.
  */
-- (RTCAudioTrack *)createAudioTrack:(NSDictionary *)constraints {
+- (LKRTCAudioTrack *)createAudioTrack:(NSDictionary *)constraints {
     NSString *trackId = [[NSUUID UUID] UUIDString];
     NSDictionary *audioConstraints = constraints[@"audio"];
     NSMutableDictionary *optionalConstraints = [NSMutableDictionary dictionary];
@@ -56,26 +56,26 @@
                                                      ? [self convertBoolToString:audioConstraints[@"highpassFilter"]]
                                                      : @"true";
 
-    RTCMediaConstraints *mediaConstraints =
-        [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil optionalConstraints:optionalConstraints];
+    LKRTCMediaConstraints *mediaConstraints =
+        [[LKRTCMediaConstraints alloc] initWithMandatoryConstraints:nil optionalConstraints:optionalConstraints];
 
-    RTCAudioSource *audioSource = [self.peerConnectionFactory audioSourceWithConstraints:mediaConstraints];
-    RTCAudioTrack *audioTrack = [self.peerConnectionFactory audioTrackWithSource:audioSource trackId:trackId];
+    LKRTCAudioSource *audioSource = [self.peerConnectionFactory audioSourceWithConstraints:mediaConstraints];
+    LKRTCAudioTrack *audioTrack = [self.peerConnectionFactory audioTrackWithSource:audioSource trackId:trackId];
     return audioTrack;
 }
 /**
- * Initializes a new {@link RTCVideoTrack} with the given capture controller
+ * Initializes a new {@link LKRTCVideoTrack} with the given capture controller
  */
-- (RTCVideoTrack *)createVideoTrackWithCaptureController:
-    (CaptureController * (^)(RTCVideoSource *))captureControllerCreator {
+- (LKRTCVideoTrack *)createVideoTrackWithCaptureController:
+    (CaptureController * (^)(LKRTCVideoSource *))captureControllerCreator {
 #if TARGET_OS_TV
     return nil;
 #else
 
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+    LKRTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    LKRTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
 
     CaptureController *captureController = captureControllerCreator(videoSource);
     videoTrack.captureController = captureController;
@@ -85,23 +85,23 @@
 #endif
 }
 /**
- * Initializes a new {@link RTCMediaTrack} with the given tracks.
+ * Initializes a new {@link LKRTCMediaTrack} with the given tracks.
  *
  * @return An array with the mediaStreamId in index 0, and track infos in index 1.
  */
-- (NSArray *)createMediaStream:(NSArray<RTCMediaStreamTrack *> *)tracks {
+- (NSArray *)createMediaStream:(NSArray<LKRTCMediaStreamTrack *> *)tracks {
 #if TARGET_OS_TV
     return nil;
 #else
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    LKRTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
     NSMutableArray<NSDictionary *> *trackInfos = [NSMutableArray array];
 
-    for (RTCMediaStreamTrack *track in tracks) {
+    for (LKRTCMediaStreamTrack *track in tracks) {
         if ([track.kind isEqualToString:@"audio"]) {
-            [mediaStream addAudioTrack:(RTCAudioTrack *)track];
+            [mediaStream addAudioTrack:(LKRTCAudioTrack *)track];
         } else if ([track.kind isEqualToString:@"video"]) {
-            [mediaStream addVideoTrack:(RTCVideoTrack *)track];
+            [mediaStream addVideoTrack:(LKRTCVideoTrack *)track];
         }
 
         NSString *trackId = track.trackId;
@@ -110,7 +110,7 @@
 
         NSDictionary *settings = @{};
         if ([track.kind isEqualToString:@"video"]) {
-            RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+            LKRTCVideoTrack *videoTrack = (LKRTCVideoTrack *)track;
             if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
                 settings = [videoTrack.captureController getSettings];
             }
@@ -137,19 +137,19 @@
 }
 
 /**
- * Initializes a new {@link RTCVideoTrack} which satisfies the given constraints.
+ * Initializes a new {@link LKRTCVideoTrack} which satisfies the given constraints.
  */
-- (RTCVideoTrack *)createVideoTrack:(NSDictionary *)constraints {
+- (LKRTCVideoTrack *)createVideoTrack:(NSDictionary *)constraints {
 #if TARGET_OS_TV
     return nil;
 #else
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+    LKRTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    LKRTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
 
 #if !TARGET_IPHONE_SIMULATOR
-    RTCCameraVideoCapturer *videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
+    LKRTCCameraVideoCapturer *videoCapturer = [[LKRTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
     VideoCaptureController *videoCaptureController =
         [[VideoCaptureController alloc] initWithCapturer:videoCapturer andConstraints:constraints[@"video"]];
     videoCaptureController.enableMultitaskingCameraAccess =
@@ -162,15 +162,15 @@
 #endif
 }
 
-- (RTCVideoTrack *)createScreenCaptureVideoTrack {
+- (LKRTCVideoTrack *)createScreenCaptureVideoTrack {
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_OSX || TARGET_OS_TV
     return nil;
 #endif
 
-    RTCVideoSource *videoSource = [self.peerConnectionFactory videoSourceForScreenCast:YES];
+    LKRTCVideoSource *videoSource = [self.peerConnectionFactory videoSourceForScreenCast:YES];
 
     NSString *trackUUID = [[NSUUID UUID] UUIDString];
-    RTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
+    LKRTCVideoTrack *videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource trackId:trackUUID];
 
     ScreenCapturer *screenCapturer = [[ScreenCapturer alloc] initWithDelegate:videoSource];
     ScreenCaptureController *screenCaptureController =
@@ -190,7 +190,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     return;
 #else
 
-    RTCVideoTrack *videoTrack = [self createScreenCaptureVideoTrack];
+    LKRTCVideoTrack *videoTrack = [self createScreenCaptureVideoTrack];
 
     if (videoTrack == nil) {
         reject(@"DOMException", @"AbortError", nil);
@@ -198,7 +198,7 @@ RCT_EXPORT_METHOD(getDisplayMedia : (RCTPromiseResolveBlock)resolve rejecter : (
     }
 
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    LKRTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
     [mediaStream addVideoTrack:videoTrack];
 
     NSString *trackId = videoTrack.trackId;
@@ -232,8 +232,8 @@ RCT_EXPORT_METHOD(getUserMedia
     errorCallback(@[ @"PlatformNotSupported", @"getUserMedia is not supported on tvOS." ]);
     return;
 #else
-    RTCAudioTrack *audioTrack = nil;
-    RTCVideoTrack *videoTrack = nil;
+    LKRTCAudioTrack *audioTrack = nil;
+    LKRTCVideoTrack *videoTrack = nil;
 
     if (constraints[@"audio"]) {
         audioTrack = [self createAudioTrack:constraints];
@@ -250,7 +250,7 @@ RCT_EXPORT_METHOD(getUserMedia
     }
 
     NSString *mediaStreamId = [[NSUUID UUID] UUIDString];
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+    LKRTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
     NSMutableArray *tracks = [NSMutableArray array];
     NSMutableArray *tmp = [NSMutableArray array];
     if (audioTrack)
@@ -258,11 +258,11 @@ RCT_EXPORT_METHOD(getUserMedia
     if (videoTrack)
         [tmp addObject:videoTrack];
 
-    for (RTCMediaStreamTrack *track in tmp) {
+    for (LKRTCMediaStreamTrack *track in tmp) {
         if ([track.kind isEqualToString:@"audio"]) {
-            [mediaStream addAudioTrack:(RTCAudioTrack *)track];
+            [mediaStream addAudioTrack:(LKRTCAudioTrack *)track];
         } else if ([track.kind isEqualToString:@"video"]) {
-            [mediaStream addVideoTrack:(RTCVideoTrack *)track];
+            [mediaStream addVideoTrack:(LKRTCVideoTrack *)track];
         }
 
         NSString *trackId = track.trackId;
@@ -271,7 +271,7 @@ RCT_EXPORT_METHOD(getUserMedia
 
         NSDictionary *settings = @{};
         if ([track.kind isEqualToString:@"video"]) {
-            RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+            LKRTCVideoTrack *videoTrack = (LKRTCVideoTrack *)track;
             if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
                 settings = [videoTrack.captureController getSettings];
             }
@@ -368,7 +368,7 @@ RCT_EXPORT_METHOD(enumerateDevices : (RCTResponseSenderBlock)callback) {
 }
 
 RCT_EXPORT_METHOD(mediaStreamCreate : (nonnull NSString *)streamID) {
-    RTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:streamID];
+    LKRTCMediaStream *mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:streamID];
     self.localStreams[streamID] = mediaStream;
 }
 
@@ -376,20 +376,20 @@ RCT_EXPORT_METHOD(mediaStreamAddTrack
                   : (nonnull NSString *)streamID
                   : (nonnull NSNumber *)pcId
                   : (nonnull NSString *)trackID) {
-    RTCMediaStream *mediaStream = self.localStreams[streamID];
+    LKRTCMediaStream *mediaStream = self.localStreams[streamID];
     if (mediaStream == nil) {
         return;
     }
 
-    RTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
+    LKRTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
     if (track == nil) {
         return;
     }
 
     if ([track.kind isEqualToString:@"audio"]) {
-        [mediaStream addAudioTrack:(RTCAudioTrack *)track];
+        [mediaStream addAudioTrack:(LKRTCAudioTrack *)track];
     } else if ([track.kind isEqualToString:@"video"]) {
-        [mediaStream addVideoTrack:(RTCVideoTrack *)track];
+        [mediaStream addVideoTrack:(LKRTCVideoTrack *)track];
     }
 }
 
@@ -397,25 +397,25 @@ RCT_EXPORT_METHOD(mediaStreamRemoveTrack
                   : (nonnull NSString *)streamID
                   : (nonnull NSNumber *)pcId
                   : (nonnull NSString *)trackID) {
-    RTCMediaStream *mediaStream = self.localStreams[streamID];
+    LKRTCMediaStream *mediaStream = self.localStreams[streamID];
     if (mediaStream == nil) {
         return;
     }
 
-    RTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
+    LKRTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
     if (track == nil) {
         return;
     }
 
     if ([track.kind isEqualToString:@"audio"]) {
-        [mediaStream removeAudioTrack:(RTCAudioTrack *)track];
+        [mediaStream removeAudioTrack:(LKRTCAudioTrack *)track];
     } else if ([track.kind isEqualToString:@"video"]) {
-        [mediaStream removeVideoTrack:(RTCVideoTrack *)track];
+        [mediaStream removeVideoTrack:(LKRTCVideoTrack *)track];
     }
 }
 
 RCT_EXPORT_METHOD(mediaStreamRelease : (nonnull NSString *)streamID) {
-    RTCMediaStream *stream = self.localStreams[streamID];
+    LKRTCMediaStream *stream = self.localStreams[streamID];
     if (stream) {
         [self.localStreams removeObjectForKey:streamID];
     }
@@ -426,7 +426,7 @@ RCT_EXPORT_METHOD(mediaStreamTrackRelease : (nonnull NSString *)trackID) {
     return;
 #else
 
-    RTCMediaStreamTrack *track = self.localTracks[trackID];
+    LKRTCMediaStreamTrack *track = self.localTracks[trackID];
     if (track) {
         track.isEnabled = NO;
         [track.captureController stopCapture];
@@ -436,7 +436,7 @@ RCT_EXPORT_METHOD(mediaStreamTrackRelease : (nonnull NSString *)trackID) {
 }
 
 RCT_EXPORT_METHOD(mediaStreamTrackSetEnabled : (nonnull NSNumber *)pcId : (nonnull NSString *)trackID : (BOOL)enabled) {
-    RTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
+    LKRTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
     if (track == nil) {
         return;
     }
@@ -462,10 +462,10 @@ RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints
     reject(@"unsupported_platform", @"tvOS is not supported", nil);
     return;
 #else
-    RTCMediaStreamTrack *track = self.localTracks[trackID];
+    LKRTCMediaStreamTrack *track = self.localTracks[trackID];
     if (track) {
         if ([track.kind isEqualToString:@"video"]) {
-            RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+            LKRTCVideoTrack *videoTrack = (LKRTCVideoTrack *)track;
             if ([videoTrack.captureController isKindOfClass:[CaptureController class]]) {
                 CaptureController *vcc = (CaptureController *)videoTrack.captureController;
                 NSError *error = nil;
@@ -488,9 +488,9 @@ RCT_EXPORT_METHOD(mediaStreamTrackApplyConstraints
 }
 
 RCT_EXPORT_METHOD(mediaStreamTrackSetVolume : (nonnull NSNumber *)pcId : (nonnull NSString *)trackID : (double)volume) {
-    RTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
+    LKRTCMediaStreamTrack *track = [self trackForId:trackID pcId:pcId];
     if (track && [track.kind isEqualToString:@"audio"]) {
-        RTCAudioTrack *audioTrack = (RTCAudioTrack *)track;
+        LKRTCAudioTrack *audioTrack = (LKRTCAudioTrack *)track;
         audioTrack.source.volume = volume;
     }
 }
@@ -498,13 +498,13 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetVolume : (nonnull NSNumber *)pcId : (nonnul
 RCT_EXPORT_METHOD(mediaStreamTrackSetVideoEffects
                   : (nonnull NSString *)trackID names
                   : (nonnull NSArray<NSString *> *)names) {
-    RTCMediaStreamTrack *track = self.localTracks[trackID];
+    LKRTCMediaStreamTrack *track = self.localTracks[trackID];
     if (track == nil) {
         return;
     }
 
-    RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
-    RTCVideoSource *videoSource = videoTrack.source;
+    LKRTCVideoTrack *videoTrack = (LKRTCVideoTrack *)track;
+    LKRTCVideoSource *videoSource = videoTrack.source;
 
     NSMutableArray *processors = [[NSMutableArray alloc] init];
     for (NSString *name in names) {
@@ -517,19 +517,19 @@ RCT_EXPORT_METHOD(mediaStreamTrackSetVideoEffects
     self.videoEffectProcessor = [[VideoEffectProcessor alloc] initWithProcessors:processors videoSource:videoSource];
 
     VideoCaptureController *vcc = (VideoCaptureController *)videoTrack.captureController;
-    RTCVideoCapturer *capturer = vcc.capturer;
+    LKRTCVideoCapturer *capturer = vcc.capturer;
 
     capturer.delegate = self.videoEffectProcessor;
 }
 
 #pragma mark - Helpers
 
-- (RTCMediaStreamTrack *)trackForId:(nonnull NSString *)trackId pcId:(nonnull NSNumber *)pcId {
+- (LKRTCMediaStreamTrack *)trackForId:(nonnull NSString *)trackId pcId:(nonnull NSNumber *)pcId {
     if ([pcId isEqualToNumber:[NSNumber numberWithInt:-1]]) {
         return self.localTracks[trackId];
     }
 
-    RTCPeerConnection *peerConnection = self.peerConnections[pcId];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[pcId];
     if (peerConnection == nil) {
         return nil;
     }

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.h
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.h
@@ -1,24 +1,24 @@
-#import <WebRTC/RTCPeerConnection.h>
+#import <LiveKitWebRTC/RTCPeerConnection.h>
 #import "DataChannelWrapper.h"
 #import "WebRTCModule.h"
 
-@interface RTCPeerConnection (React)
+@interface LKRTCPeerConnection (React)
 
 @property(nonatomic, strong) NSNumber *reactTag;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, DataChannelWrapper *> *dataChannels;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *remoteStreams;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *remoteTracks;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCMediaStream *> *remoteStreams;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCMediaStreamTrack *> *remoteTracks;
 @property(nonatomic, weak) id webRTCModule;
 
 @end
 
-@interface WebRTCModule (RTCPeerConnection)<RTCPeerConnectionDelegate>
+@interface WebRTCModule (LKRTCPeerConnection)<LKRTCPeerConnectionDelegate>
 
-- (nullable RTCRtpSender *)getSenderByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
+- (nullable LKRTCRtpSender *)getSenderByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
                                               senderId:(nonnull NSString *)senderId;
-- (nullable RTCRtpReceiver *)getReceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
+- (nullable LKRTCRtpReceiver *)getReceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
                                                 receiverId:(nonnull NSString *)receiverId;
-- (nullable RTCRtpTransceiver *)getTransceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
+- (nullable LKRTCRtpTransceiver *)getTransceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
                                                    transceiverId:(nonnull NSString *)transceiverId;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCPeerConnection.m
@@ -5,15 +5,15 @@
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
-#import <WebRTC/RTCConfiguration.h>
-#import <WebRTC/RTCIceCandidate.h>
-#import <WebRTC/RTCIceServer.h>
-#import <WebRTC/RTCMediaConstraints.h>
-#import <WebRTC/RTCMediaStreamTrack.h>
-#import <WebRTC/RTCRtpReceiver.h>
-#import <WebRTC/RTCRtpTransceiver.h>
-#import <WebRTC/RTCSessionDescription.h>
-#import <WebRTC/RTCStatisticsReport.h>
+#import <LiveKitWebRTC/RTCConfiguration.h>
+#import <LiveKitWebRTC/RTCIceCandidate.h>
+#import <LiveKitWebRTC/RTCIceServer.h>
+#import <LiveKitWebRTC/RTCMediaConstraints.h>
+#import <LiveKitWebRTC/RTCMediaStreamTrack.h>
+#import <LiveKitWebRTC/RTCRtpReceiver.h>
+#import <LiveKitWebRTC/RTCRtpTransceiver.h>
+#import <LiveKitWebRTC/RTCSessionDescription.h>
+#import <LiveKitWebRTC/RTCStatisticsReport.h>
 
 #import "SerializeUtils.h"
 #import "WebRTCModule+RTCDataChannel.h"
@@ -22,7 +22,7 @@
 #import "WebRTCModule.h"
 #import "WebRTCModuleOptions.h"
 
-@implementation RTCPeerConnection (React)
+@implementation LKRTCPeerConnection (React)
 
 - (NSMutableDictionary<NSString *, DataChannelWrapper *> *)dataChannels {
     return objc_getAssociatedObject(self, _cmd);
@@ -40,19 +40,19 @@
     objc_setAssociatedObject(self, @selector(reactTag), reactTag, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (NSMutableDictionary<NSString *, RTCMediaStream *> *)remoteStreams {
+- (NSMutableDictionary<NSString *, LKRTCMediaStream *> *)remoteStreams {
     return objc_getAssociatedObject(self, _cmd);
 }
 
-- (void)setRemoteStreams:(NSMutableDictionary<NSString *, RTCMediaStream *> *)remoteStreams {
+- (void)setRemoteStreams:(NSMutableDictionary<NSString *, LKRTCMediaStream *> *)remoteStreams {
     objc_setAssociatedObject(self, @selector(remoteStreams), remoteStreams, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *)remoteTracks {
+- (NSMutableDictionary<NSString *, LKRTCMediaStreamTrack *> *)remoteTracks {
     return objc_getAssociatedObject(self, _cmd);
 }
 
-- (void)setRemoteTracks:(NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *)remoteTracks {
+- (void)setRemoteTracks:(NSMutableDictionary<NSString *, LKRTCMediaStreamTrack *> *)remoteTracks {
     objc_setAssociatedObject(self, @selector(remoteTracks), remoteTracks, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
@@ -66,19 +66,19 @@
 
 @end
 
-@implementation WebRTCModule (RTCPeerConnection)
+@implementation WebRTCModule (LKRTCPeerConnection)
 
 int _transceiverNextId = 0;
 
-- (nullable RTCRtpSender *)getSenderByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
+- (nullable LKRTCRtpSender *)getSenderByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
                                               senderId:(nonnull NSString *)senderId {
-    RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
     if (!peerConnection) {
         RCTLogWarn(@"PeerConnection %@ not found", peerConnectionId);
         return nil;
     }
-    RTCRtpSender *sender = nil;
-    for (RTCRtpSender *s in peerConnection.senders) {
+    LKRTCRtpSender *sender = nil;
+    for (LKRTCRtpSender *s in peerConnection.senders) {
         if ([senderId isEqual:s.senderId]) {
             sender = s;
             break;
@@ -87,15 +87,15 @@ int _transceiverNextId = 0;
 
     return sender;
 }
-- (nullable RTCRtpReceiver *)getReceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
+- (nullable LKRTCRtpReceiver *)getReceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
                                                 receiverId:(nonnull NSString *)receiverId {
-    RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
     if (!peerConnection) {
         RCTLogWarn(@"PeerConnection %@ not found", peerConnectionId);
         return nil;
     }
-    RTCRtpReceiver *receiver = nil;
-    for (RTCRtpReceiver *r in peerConnection.receivers) {
+    LKRTCRtpReceiver *receiver = nil;
+    for (LKRTCRtpReceiver *r in peerConnection.receivers) {
         if ([receiverId isEqual:r.receiverId]) {
             receiver = r;
             break;
@@ -105,15 +105,15 @@ int _transceiverNextId = 0;
     return receiver;
 }
 
-- (nullable RTCRtpTransceiver *)getTransceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
+- (nullable LKRTCRtpTransceiver *)getTransceiverByPeerConnectionId:(nonnull NSNumber *)peerConnectionId
                                                    transceiverId:(nonnull NSString *)transceiverId {
-    RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
     if (!peerConnection) {
         RCTLogWarn(@"PeerConnection %@ not found", peerConnectionId);
         return nil;
     }
-    RTCRtpTransceiver *transceiver = nil;
-    for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+    LKRTCRtpTransceiver *transceiver = nil;
+    for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
         if ([transceiverId isEqual:t.sender.senderId]) {
             transceiver = t;
             break;
@@ -127,14 +127,14 @@ int _transceiverNextId = 0;
  * in the same way (synchronous) since the peer connection needs to exist before.
  */
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
-                                       : (RTCConfiguration *)configuration objectID
+                                       : (LKRTCConfiguration *)configuration objectID
                                        : (nonnull NSNumber *)objectID) {
     __block BOOL ret = YES;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:nil
+        LKRTCMediaConstraints *constraints = [[LKRTCMediaConstraints alloc] initWithMandatoryConstraints:nil
                                                                                  optionalConstraints:nil];
-        RTCPeerConnection *peerConnection = [self.peerConnectionFactory peerConnectionWithConfiguration:configuration
+        LKRTCPeerConnection *peerConnection = [self.peerConnectionFactory peerConnectionWithConfiguration:configuration
                                                                                             constraints:constraints
                                                                                                delegate:self];
         if (peerConnection == nil) {
@@ -156,9 +156,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionInit
 }
 
 RCT_EXPORT_METHOD(peerConnectionSetConfiguration
-                  : (RTCConfiguration *)configuration objectID
+                  : (LKRTCConfiguration *)configuration objectID
                   : (nonnull NSNumber *)objectID) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         return;
     }
@@ -170,27 +170,27 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer
                   : (NSDictionary *)options resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         reject(@"E_INVALID", @"PeerConnection not found", nil);
         return;
     }
 
-    RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:options
+    LKRTCMediaConstraints *constraints = [[LKRTCMediaConstraints alloc] initWithMandatoryConstraints:options
                                                                              optionalConstraints:nil];
 
     NSMutableArray *receiversIds = [NSMutableArray new];
-    for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+    for (LKRTCRtpTransceiver *transceiver in peerConnection.transceivers) {
         [receiversIds addObject:transceiver.receiver.receiverId];
     }
 
-    RTCCreateSessionDescriptionCompletionHandler handler = ^(RTCSessionDescription *desc, NSError *error) {
+    LKRTCCreateSessionDescriptionCompletionHandler handler = ^(LKRTCSessionDescription *desc, NSError *error) {
         dispatch_async(self.workerQueue, ^{
             if (error) {
                 reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
             } else {
                 NSMutableArray *newTransceivers = [NSMutableArray new];
-                for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+                for (LKRTCRtpTransceiver *transceiver in peerConnection.transceivers) {
                     if (![receiversIds containsObject:transceiver.receiver.receiverId]) {
                         NSMutableDictionary *newTransceiver = [NSMutableDictionary new];
                         newTransceiver[@"transceiverOrder"] = [NSNumber numberWithInt:_transceiverNextId++];
@@ -200,7 +200,7 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer
                     }
                 }
                 id data = @{
-                    @"sdpInfo" : @{@"type" : [RTCSessionDescription stringForType:desc.type], @"sdp" : desc.sdp},
+                    @"sdpInfo" : @{@"type" : [LKRTCSessionDescription stringForType:desc.type], @"sdp" : desc.sdp},
                     @"transceiversInfo" :
                         [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection],
                     @"newTransceivers" : newTransceivers
@@ -218,22 +218,22 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer
                   : (NSDictionary *)options resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         reject(@"E_INVALID", @"PeerConnection not found", nil);
         return;
     }
 
-    RTCMediaConstraints *constraints = [[RTCMediaConstraints alloc] initWithMandatoryConstraints:options
+    LKRTCMediaConstraints *constraints = [[LKRTCMediaConstraints alloc] initWithMandatoryConstraints:options
                                                                              optionalConstraints:nil];
 
-    RTCCreateSessionDescriptionCompletionHandler handler = ^(RTCSessionDescription *desc, NSError *error) {
+    LKRTCCreateSessionDescriptionCompletionHandler handler = ^(LKRTCSessionDescription *desc, NSError *error) {
         dispatch_async(self.workerQueue, ^{
             if (error) {
                 reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
             } else {
                 id data = @{
-                    @"sdpInfo" : @{@"type" : [RTCSessionDescription stringForType:desc.type], @"sdp" : desc.sdp},
+                    @"sdpInfo" : @{@"type" : [LKRTCSessionDescription stringForType:desc.type], @"sdp" : desc.sdp},
                     @"transceiversInfo" :
                         [SerializeUtils constructTransceiversInfoArrayWithPeerConnection:peerConnection]
                 };
@@ -247,24 +247,24 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer
 
 RCT_EXPORT_METHOD(peerConnectionSetLocalDescription
                   : (nonnull NSNumber *)objectID desc
-                  : (RTCSessionDescription *)desc resolver
+                  : (LKRTCSessionDescription *)desc resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         reject(@"E_INVALID", @"PeerConnection not found", nil);
         return;
     }
 
-    RTCSetSessionDescriptionCompletionHandler handler = ^(NSError *error) {
+    LKRTCSetSessionDescriptionCompletionHandler handler = ^(NSError *error) {
         dispatch_async(self.workerQueue, ^{
             if (error) {
                 reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
             } else {
                 NSMutableDictionary *sdpInfo = [NSMutableDictionary new];
-                RTCSessionDescription *localDesc = peerConnection.localDescription;
+                LKRTCSessionDescription *localDesc = peerConnection.localDescription;
                 if (localDesc) {
-                    sdpInfo[@"type"] = [RTCSessionDescription stringForType:localDesc.type];
+                    sdpInfo[@"type"] = [LKRTCSessionDescription stringForType:localDesc.type];
                     sdpInfo[@"sdp"] = localDesc.sdp;
                 }
                 id data = @{
@@ -286,27 +286,27 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription
 
 RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription
                   : (nonnull NSNumber *)objectID desc
-                  : (RTCSessionDescription *)desc resolver
+                  : (LKRTCSessionDescription *)desc resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         reject(@"E_INVALID", @"PeerConnection not found", nil);
         return;
     }
 
     NSMutableArray *receiversIds = [NSMutableArray new];
-    for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+    for (LKRTCRtpTransceiver *transceiver in peerConnection.transceivers) {
         [receiversIds addObject:transceiver.receiver.receiverId];
     }
 
-    RTCSetSessionDescriptionCompletionHandler handler = ^(NSError *error) {
+    LKRTCSetSessionDescriptionCompletionHandler handler = ^(NSError *error) {
         dispatch_async(self.workerQueue, ^{
             if (error) {
                 reject(@"E_OPERATION_ERROR", error.localizedDescription, nil);
             } else {
                 NSMutableArray *newTransceivers = [NSMutableArray new];
-                for (RTCRtpTransceiver *transceiver in peerConnection.transceivers) {
+                for (LKRTCRtpTransceiver *transceiver in peerConnection.transceivers) {
                     if (![receiversIds containsObject:transceiver.receiver.receiverId]) {
                         NSMutableDictionary *newTransceiver = [NSMutableDictionary new];
                         newTransceiver[@"transceiverOrder"] = [NSNumber numberWithInt:_transceiverNextId++];
@@ -317,9 +317,9 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription
                 }
 
                 NSMutableDictionary *sdpInfo = [NSMutableDictionary new];
-                RTCSessionDescription *remoteDesc = peerConnection.remoteDescription;
+                LKRTCSessionDescription *remoteDesc = peerConnection.remoteDescription;
                 if (remoteDesc) {
-                    sdpInfo[@"type"] = [RTCSessionDescription stringForType:remoteDesc.type];
+                    sdpInfo[@"type"] = [LKRTCSessionDescription stringForType:remoteDesc.type];
                     sdpInfo[@"sdp"] = remoteDesc.sdp;
                 }
                 id data = @{
@@ -338,10 +338,10 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription
 
 RCT_EXPORT_METHOD(peerConnectionAddICECandidate
                   : (nonnull NSNumber *)objectID candidate
-                  : (RTCIceCandidate *)candidate resolver
+                  : (LKRTCIceCandidate *)candidate resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         reject(@"E_INVALID", @"PeerConnection not found", nil);
         return;
@@ -352,8 +352,8 @@ RCT_EXPORT_METHOD(peerConnectionAddICECandidate
             if (error) {
                 reject(@"E_OPERATION_ERROR", @"addIceCandidate failed", error);
             } else {
-                RTCSessionDescription *remoteDesc = peerConnection.remoteDescription;
-                id newSdp = @{@"type" : [RTCSessionDescription stringForType:remoteDesc.type], @"sdp" : remoteDesc.sdp};
+                LKRTCSessionDescription *remoteDesc = peerConnection.remoteDescription;
+                id newSdp = @{@"type" : [LKRTCSessionDescription stringForType:remoteDesc.type], @"sdp" : remoteDesc.sdp};
                 resolve(newSdp);
             }
         });
@@ -363,7 +363,7 @@ RCT_EXPORT_METHOD(peerConnectionAddICECandidate
 }
 
 RCT_EXPORT_METHOD(peerConnectionClose : (nonnull NSNumber *)objectID) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         return;
     }
@@ -372,16 +372,16 @@ RCT_EXPORT_METHOD(peerConnectionClose : (nonnull NSNumber *)objectID) {
 }
 
 RCT_EXPORT_METHOD(peerConnectionDispose : (nonnull NSNumber *)objectID) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         return;
     }
 
     // Remove video track adapters
     for (NSString *key in peerConnection.remoteTracks.allKeys) {
-        RTCMediaStreamTrack *track = peerConnection.remoteTracks[key];
-        if (track.kind == kRTCMediaStreamTrackKindVideo) {
-            [peerConnection removeVideoTrackAdapter:(RTCVideoTrack *)track];
+        LKRTCMediaStreamTrack *track = peerConnection.remoteTracks[key];
+        if (track.kind == kLKRTCMediaStreamTrackKindVideo) {
+            [peerConnection removeVideoTrackAdapter:(LKRTCVideoTrack *)track];
         }
     }
 
@@ -393,8 +393,8 @@ RCT_EXPORT_METHOD(peerConnectionDispose : (nonnull NSNumber *)objectID) {
     NSMutableDictionary<NSString *, DataChannelWrapper *> *dataChannels = peerConnection.dataChannels;
     for (NSString *tag in dataChannels) {
         dataChannels[tag].delegate = nil;
-        // There is no need to close the RTCDataChannel because it is owned by the
-        // RTCPeerConnection and the latter will close the former.
+        // There is no need to close the LKRTCDataChannel because it is owned by the
+        // LKRTCPeerConnection and the latter will close the former.
     }
     [dataChannels removeAllObjects];
 
@@ -405,14 +405,14 @@ RCT_EXPORT_METHOD(peerConnectionGetStats
                   : (nonnull NSNumber *)objectID resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         RCTLogWarn(@"PeerConnection %@ not found in peerConnectionGetStats()", objectID);
         resolve(@"[]");
         return;
     }
 
-    [peerConnection statisticsWithCompletionHandler:^(RTCStatisticsReport *report) {
+    [peerConnection statisticsWithCompletionHandler:^(LKRTCStatisticsReport *report) {
         resolve([self statsToJSON:report]);
     }];
 }
@@ -422,15 +422,15 @@ RCT_EXPORT_METHOD(receiverGetStats
                   : (nonnull NSString *)receiverId resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[pcId];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[pcId];
     if (!peerConnection) {
         RCTLogWarn(@"PeerConnection %@ not found in receiverGetStats()", pcId);
         resolve(@"[]");
         return;
     }
 
-    RTCRtpReceiver *receiver;
-    for (RTCRtpReceiver *findRecv in peerConnection.receivers) {
+    LKRTCRtpReceiver *receiver;
+    for (LKRTCRtpReceiver *findRecv in peerConnection.receivers) {
         if ([findRecv.receiverId isEqualToString:receiverId]) {
             receiver = findRecv;
             break;
@@ -438,13 +438,13 @@ RCT_EXPORT_METHOD(receiverGetStats
     }
 
     if (!receiver) {
-        RCTLogWarn(@"RTCRtpReceiver %@ not found in receiverGetStats()", receiverId);
+        RCTLogWarn(@"LKRTCRtpReceiver %@ not found in receiverGetStats()", receiverId);
         resolve(@"[]");
         return;
     }
 
     [peerConnection statisticsForReceiver:receiver
-                        completionHandler:^(RTCStatisticsReport *report) {
+                        completionHandler:^(LKRTCStatisticsReport *report) {
                             resolve([self statsToJSON:report]);
                         }];
 }
@@ -454,15 +454,15 @@ RCT_EXPORT_METHOD(senderGetStats
                   : (nonnull NSString *)senderId resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[pcId];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[pcId];
     if (!peerConnection) {
         RCTLogWarn(@"PeerConnection %@ not found in senderGetStats()", pcId);
         resolve(@"[]");
         return;
     }
 
-    RTCRtpSender *sender;
-    for (RTCRtpSender *findSend in peerConnection.senders) {
+    LKRTCRtpSender *sender;
+    for (LKRTCRtpSender *findSend in peerConnection.senders) {
         if ([findSend.senderId isEqualToString:senderId]) {
             sender = findSend;
             break;
@@ -470,19 +470,19 @@ RCT_EXPORT_METHOD(senderGetStats
     }
 
     if (!sender) {
-        RCTLogWarn(@"RTCRtpSender %@ not found in senderGetStats()", senderId);
+        RCTLogWarn(@"LKRTCRtpSender %@ not found in senderGetStats()", senderId);
         resolve(@"[]");
         return;
     }
 
     [peerConnection statisticsForSender:sender
-                      completionHandler:^(RTCStatisticsReport *report) {
+                      completionHandler:^(LKRTCStatisticsReport *report) {
                           resolve([self statsToJSON:report]);
                       }];
 }
 
 RCT_EXPORT_METHOD(peerConnectionRestartIce : (nonnull NSNumber *)objectID) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
     if (!peerConnection) {
         return;
     }
@@ -497,19 +497,19 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionAddTrack
     __block id params = nil;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+        LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
         if (!peerConnection) {
             RCTLogWarn(@"PeerConnection %@ not found in peerConnectionAddTrack()", objectID);
             return;
         }
 
-        RTCMediaStreamTrack *track = self.localTracks[trackId];
+        LKRTCMediaStreamTrack *track = self.localTracks[trackId];
 
         NSArray *streamIds = [options objectForKey:@"streamIds"];
-        RTCRtpSender *sender = [peerConnection addTrack:track streamIds:streamIds];
-        RTCRtpTransceiver *transceiver = nil;
+        LKRTCRtpSender *sender = [peerConnection addTrack:track streamIds:streamIds];
+        LKRTCRtpTransceiver *transceiver = nil;
 
-        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+        for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
             if ([t.sender.senderId isEqual:sender.senderId]) {
                 transceiver = t;
                 break;
@@ -537,37 +537,37 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionAddTransceiver
     __block id params = nil;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+        LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
         if (!peerConnection) {
             RCTLogWarn(@"PeerConnection %@ not found in peerConnectionAddTransceiver()", objectID);
             return;
         }
 
-        RTCRtpTransceiver *transceiver = nil;
+        LKRTCRtpTransceiver *transceiver = nil;
         NSString *kind = [options objectForKey:@"type"];
         NSString *trackId = [options objectForKey:@"trackId"];
-        RTCRtpMediaType type = RTCRtpMediaTypeUnsupported;
+        LKRTCRtpMediaType type = LKRTCRtpMediaTypeUnsupported;
 
         if (kind) {
             if ([kind isEqual:@"audio"]) {
-                type = RTCRtpMediaTypeAudio;
+                type = LKRTCRtpMediaTypeAudio;
             } else if ([kind isEqual:@"video"]) {
-                type = RTCRtpMediaTypeVideo;
+                type = LKRTCRtpMediaTypeVideo;
             }
 
             NSDictionary *initOptions = [options objectForKey:@"init"];
-            RTCRtpTransceiverInit *transceiverInit = [SerializeUtils parseTransceiverOptions:initOptions];
+            LKRTCRtpTransceiverInit *transceiverInit = [SerializeUtils parseTransceiverOptions:initOptions];
 
             transceiver = [peerConnection addTransceiverOfType:type init:transceiverInit];
         } else if (trackId) {
-            RTCMediaStreamTrack *track = self.localTracks[trackId];
+            LKRTCMediaStreamTrack *track = self.localTracks[trackId];
 
             if (!track) {
                 track = peerConnection.remoteTracks[trackId];
             }
 
             NSDictionary *initOptions = [options objectForKey:@"init"];
-            RTCRtpTransceiverInit *transceiverInit = [SerializeUtils parseTransceiverOptions:initOptions];
+            LKRTCRtpTransceiverInit *transceiverInit = [SerializeUtils parseTransceiverOptions:initOptions];
 
             transceiver = [peerConnection addTransceiverWithTrack:track init:transceiverInit];
         } else {
@@ -595,15 +595,15 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     __block BOOL ret = NO;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+        LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
         if (!peerConnection) {
             RCTLogWarn(@"PeerConnection %@ not found in peerConnectionRemoveTrack()", objectID);
             return;
         }
 
-        RTCRtpSender *sender = nil;
+        LKRTCRtpSender *sender = nil;
 
-        for (RTCRtpSender *s in peerConnection.senders) {
+        for (LKRTCRtpSender *s in peerConnection.senders) {
             if ([s.senderId isEqual:senderId]) {
                 sender = s;
                 break;
@@ -625,14 +625,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
 
 /**
  * Constructs a JSON <tt>NSString</tt> representation of a specific
- * <tt>RTCStatisticsReport</tt>s.
+ * <tt>LKRTCStatisticsReport</tt>s.
  * <p>
  *
- * @param <tt>RTCStatisticsReport</tt>s
+ * @param <tt>LKRTCStatisticsReport</tt>s
  * @return an <tt>NSString</tt> which represents the specified <tt>report</tt> in
  * JSON format
  */
-- (NSString *)statsToJSON:(RTCStatisticsReport *)report {
+- (NSString *)statsToJSON:(LKRTCStatisticsReport *)report {
     /*
     The initial capacity matters, of course, because it determines how many
     times the NSMutableString will have grow. But walking through the reports
@@ -658,7 +658,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
         [s appendString:key];
         [s appendString:@"\",{"];
 
-        RTCStatistics *statistics = report.statistics[key];
+        LKRTCStatistics *statistics = report.statistics[key];
         [s appendString:@"\"timestamp\":"];
         [s appendFormat:@"%f", statistics.timestamp_us / 1000.0];
         [s appendString:@",\"type\":\""];
@@ -722,79 +722,79 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     }
 }
 
-- (NSString *)stringForPeerConnectionState:(RTCPeerConnectionState)state {
+- (NSString *)stringForPeerConnectionState:(LKRTCPeerConnectionState)state {
     switch (state) {
-        case RTCPeerConnectionStateNew:
+        case LKRTCPeerConnectionStateNew:
             return @"new";
-        case RTCPeerConnectionStateConnecting:
+        case LKRTCPeerConnectionStateConnecting:
             return @"connecting";
-        case RTCPeerConnectionStateConnected:
+        case LKRTCPeerConnectionStateConnected:
             return @"connected";
-        case RTCPeerConnectionStateDisconnected:
+        case LKRTCPeerConnectionStateDisconnected:
             return @"disconnected";
-        case RTCPeerConnectionStateFailed:
+        case LKRTCPeerConnectionStateFailed:
             return @"failed";
-        case RTCPeerConnectionStateClosed:
+        case LKRTCPeerConnectionStateClosed:
             return @"closed";
     }
     return nil;
 }
 
-- (NSString *)stringForICEConnectionState:(RTCIceConnectionState)state {
+- (NSString *)stringForICEConnectionState:(LKRTCIceConnectionState)state {
     switch (state) {
-        case RTCIceConnectionStateNew:
+        case LKRTCIceConnectionStateNew:
             return @"new";
-        case RTCIceConnectionStateChecking:
+        case LKRTCIceConnectionStateChecking:
             return @"checking";
-        case RTCIceConnectionStateConnected:
+        case LKRTCIceConnectionStateConnected:
             return @"connected";
-        case RTCIceConnectionStateCompleted:
+        case LKRTCIceConnectionStateCompleted:
             return @"completed";
-        case RTCIceConnectionStateFailed:
+        case LKRTCIceConnectionStateFailed:
             return @"failed";
-        case RTCIceConnectionStateDisconnected:
+        case LKRTCIceConnectionStateDisconnected:
             return @"disconnected";
-        case RTCIceConnectionStateClosed:
+        case LKRTCIceConnectionStateClosed:
             return @"closed";
-        case RTCIceConnectionStateCount:
+        case LKRTCIceConnectionStateCount:
             return @"count";
     }
     return nil;
 }
 
-- (NSString *)stringForICEGatheringState:(RTCIceGatheringState)state {
+- (NSString *)stringForICEGatheringState:(LKRTCIceGatheringState)state {
     switch (state) {
-        case RTCIceGatheringStateNew:
+        case LKRTCIceGatheringStateNew:
             return @"new";
-        case RTCIceGatheringStateGathering:
+        case LKRTCIceGatheringStateGathering:
             return @"gathering";
-        case RTCIceGatheringStateComplete:
+        case LKRTCIceGatheringStateComplete:
             return @"complete";
     }
     return nil;
 }
 
-- (NSString *)stringForSignalingState:(RTCSignalingState)state {
+- (NSString *)stringForSignalingState:(LKRTCSignalingState)state {
     switch (state) {
-        case RTCSignalingStateStable:
+        case LKRTCSignalingStateStable:
             return @"stable";
-        case RTCSignalingStateHaveLocalOffer:
+        case LKRTCSignalingStateHaveLocalOffer:
             return @"have-local-offer";
-        case RTCSignalingStateHaveLocalPrAnswer:
+        case LKRTCSignalingStateHaveLocalPrAnswer:
             return @"have-local-pranswer";
-        case RTCSignalingStateHaveRemoteOffer:
+        case LKRTCSignalingStateHaveRemoteOffer:
             return @"have-remote-offer";
-        case RTCSignalingStateHaveRemotePrAnswer:
+        case LKRTCSignalingStateHaveRemotePrAnswer:
             return @"have-remote-pranswer";
-        case RTCSignalingStateClosed:
+        case LKRTCSignalingStateClosed:
             return @"closed";
     }
     return nil;
 }
 
-#pragma mark - RTCPeerConnectionDelegate methods
+#pragma mark - LKRTCPeerConnectionDelegate methods
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeSignalingState:(RTCSignalingState)newState {
+- (void)peerConnection:(LKRTCPeerConnection *)peerConnection didChangeSignalingState:(LKRTCSignalingState)newState {
     dispatch_async(self.workerQueue, ^{
         [self sendEventWithName:kEventPeerConnectionSignalingStateChanged
                            body:@{
@@ -804,13 +804,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnectionShouldNegotiate:(RTCPeerConnection *)peerConnection {
+- (void)peerConnectionShouldNegotiate:(LKRTCPeerConnection *)peerConnection {
     dispatch_async(self.workerQueue, ^{
         [self sendEventWithName:kEventPeerConnectionOnRenegotiationNeeded body:@{@"pcId" : peerConnection.reactTag}];
     });
 }
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeConnectionState:(RTCPeerConnectionState)newState {
+- (void)peerConnection:(LKRTCPeerConnection *)peerConnection didChangeConnectionState:(LKRTCPeerConnectionState)newState {
     dispatch_async(self.workerQueue, ^{
         [self sendEventWithName:kEventPeerConnectionStateChanged
                            body:@{
@@ -820,7 +820,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeIceConnectionState:(RTCIceConnectionState)newState {
+- (void)peerConnection:(LKRTCPeerConnection *)peerConnection didChangeIceConnectionState:(LKRTCIceConnectionState)newState {
     dispatch_async(self.workerQueue, ^{
         [self sendEventWithName:kEventPeerConnectionIceConnectionChanged
                            body:@{
@@ -830,14 +830,14 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didChangeIceGatheringState:(RTCIceGatheringState)newState {
+- (void)peerConnection:(LKRTCPeerConnection *)peerConnection didChangeIceGatheringState:(LKRTCIceGatheringState)newState {
     dispatch_async(self.workerQueue, ^{
         id newSdp = @{};
-        if (newState == RTCIceGatheringStateComplete) {
+        if (newState == LKRTCIceGatheringStateComplete) {
             // Can happen when doing a rollback.
             if (peerConnection.localDescription) {
                 newSdp = @{
-                    @"type" : [RTCSessionDescription stringForType:peerConnection.localDescription.type],
+                    @"type" : [LKRTCSessionDescription stringForType:peerConnection.localDescription.type],
                     @"sdp" : peerConnection.localDescription.sdp
                 };
             }
@@ -852,13 +852,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didGenerateIceCandidate:(RTCIceCandidate *)candidate {
+- (void)peerConnection:(LKRTCPeerConnection *)peerConnection didGenerateIceCandidate:(LKRTCIceCandidate *)candidate {
     dispatch_async(self.workerQueue, ^{
         id newSdp = @{};
         // Can happen when doing a rollback.
         if (peerConnection.localDescription) {
             newSdp = @{
-                @"type" : [RTCSessionDescription stringForType:peerConnection.localDescription.type],
+                @"type" : [LKRTCSessionDescription stringForType:peerConnection.localDescription.type],
                 @"sdp" : peerConnection.localDescription.sdp
             };
         }
@@ -876,7 +876,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(RTCPeerConnection *)peerConnection didOpenDataChannel:(RTCDataChannel *)dataChannel {
+- (void)peerConnection:(LKRTCPeerConnection *)peerConnection didOpenDataChannel:(LKRTCDataChannel *)dataChannel {
     dispatch_async(self.workerQueue, ^{
         NSString *reactTag = [[NSUUID UUID] UUIDString];
         DataChannelWrapper *dcw = [[DataChannelWrapper alloc] initWithChannel:dataChannel reactTag:reactTag];
@@ -902,12 +902,12 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
-        didAddReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)rtpReceiver
-               streams:(NSArray<RTC_OBJC_TYPE(RTCMediaStream) *> *)mediaStreams {
+- (void)peerConnection:(RTC_OBJC_TYPE(LKRTCPeerConnection) *)peerConnection
+        didAddReceiver:(RTC_OBJC_TYPE(LKRTCRtpReceiver) *)rtpReceiver
+               streams:(NSArray<RTC_OBJC_TYPE(LKRTCMediaStream) *> *)mediaStreams {
     dispatch_async(self.workerQueue, ^{
-        RTCRtpTransceiver *transceiver = nil;
-        for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+        LKRTCRtpTransceiver *transceiver = nil;
+        for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
             if ([rtpReceiver.receiverId isEqual:t.receiver.receiverId]) {
                 transceiver = t;
                 break;
@@ -919,7 +919,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
             return;
         }
 
-        RTCMediaStreamTrack *track = rtpReceiver.track;
+        LKRTCMediaStreamTrack *track = rtpReceiver.track;
 
         // We need to fire this event for an existing track sometimes, like
         // when the transceiver direction (on the sending side) switches from
@@ -927,11 +927,11 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
         BOOL existingTrack = peerConnection.remoteTracks[track.trackId] != nil;
 
         if (!existingTrack) {
-            if (track.kind == kRTCMediaStreamTrackKindVideo) {
-                RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
+            if (track.kind == kLKRTCMediaStreamTrackKindVideo) {
+                LKRTCVideoTrack *videoTrack = (LKRTCVideoTrack *)track;
                 [peerConnection addVideoTrackAdapter:videoTrack];
-            } else if (track.kind == kRTCMediaStreamTrackKindAudio) {
-                RTCAudioTrack *audioTrack = (RTCAudioTrack *)track;
+            } else if (track.kind == kLKRTCMediaStreamTrackKindAudio) {
+                LKRTCAudioTrack *audioTrack = (LKRTCAudioTrack *)track;
                 WebRTCModuleOptions *options = [WebRTCModuleOptions sharedInstance];
                 audioTrack.source.volume = options.defaultTrackVolume;
             }
@@ -942,7 +942,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
         NSMutableDictionary *params = [NSMutableDictionary new];
         NSMutableArray *streams = [NSMutableArray new];
 
-        for (RTCMediaStream *stream in mediaStreams) {
+        for (LKRTCMediaStream *stream in mediaStreams) {
             NSString *streamReactTag = nil;
 
             for (NSString *key in [peerConnection.remoteStreams allKeys]) {
@@ -976,8 +976,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(RTC_OBJC_TYPE(RTCPeerConnection) *)peerConnection
-     didRemoveReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)rtpReceiver {
+- (void)peerConnection:(RTC_OBJC_TYPE(LKRTCPeerConnection) *)peerConnection
+     didRemoveReceiver:(RTC_OBJC_TYPE(LKRTCRtpReceiver) *)rtpReceiver {
     dispatch_async(self.workerQueue, ^{
         NSMutableDictionary *params = [NSMutableDictionary new];
 
@@ -988,16 +988,16 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(peerConnectionRemoveTrack
     });
 }
 
-- (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection
-    didRemoveIceCandidates:(nonnull NSArray<RTCIceCandidate *> *)candidates {
+- (void)peerConnection:(nonnull LKRTCPeerConnection *)peerConnection
+    didRemoveIceCandidates:(nonnull NSArray<LKRTCIceCandidate *> *)candidates {
     // Unimplemented, there is no matching web API.
 }
 
-- (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didAddStream:(nonnull RTCMediaStream *)stream {
+- (void)peerConnection:(nonnull LKRTCPeerConnection *)peerConnection didAddStream:(nonnull LKRTCMediaStream *)stream {
     // Unused in Unified Plan.
 }
 
-- (void)peerConnection:(nonnull RTCPeerConnection *)peerConnection didRemoveStream:(nonnull RTCMediaStream *)stream {
+- (void)peerConnection:(nonnull LKRTCPeerConnection *)peerConnection didRemoveStream:(nonnull LKRTCMediaStream *)stream {
     // Unused in Unified Plan.
 }
 

--- a/ios/RCTWebRTC/WebRTCModule+Transceivers.m
+++ b/ios/RCTWebRTC/WebRTCModule+Transceivers.m
@@ -3,9 +3,9 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
 
-#import <WebRTC/RTCRtpCodecCapability.h>
-#import <WebRTC/RTCRtpReceiver.h>
-#import <WebRTC/RTCRtpSender.h>
+#import <LiveKitWebRTC/RTCRtpCodecCapability.h>
+#import <LiveKitWebRTC/RTCRtpReceiver.h>
+#import <LiveKitWebRTC/RTCRtpSender.h>
 
 #import "SerializeUtils.h"
 #import "WebRTCModule.h"
@@ -16,7 +16,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(senderGetCapabilities : (NSString *)kind)
     __block id params;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpSenderCapabilitiesForKind:kind];
+        LKRTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpSenderCapabilitiesForKind:kind];
         params = [SerializeUtils capabilitiesToJSON:capabilities];
     });
 
@@ -27,7 +27,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(receiverGetCapabilities : (NSString *)kin
     __block id params;
 
     dispatch_sync(self.workerQueue, ^{
-        RTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpReceiverCapabilitiesForKind:kind];
+        LKRTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpReceiverCapabilitiesForKind:kind];
         params = [SerializeUtils capabilitiesToJSON:capabilities];
     });
 
@@ -40,15 +40,15 @@ RCT_EXPORT_METHOD(senderReplaceTrack
                   : (NSString *)trackId resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
     if (peerConnection == nil) {
         RCTLogWarn(@"PeerConnection %@ not found in senderReplaceTrack()", objectID);
         reject(@"E_INVALID", @"Peer Connection is not initialized", nil);
     }
 
-    RTCRtpTransceiver *transceiver = nil;
-    for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+    LKRTCRtpTransceiver *transceiver = nil;
+    for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
         if ([senderId isEqual:t.sender.senderId]) {
             transceiver = t;
             break;
@@ -60,8 +60,8 @@ RCT_EXPORT_METHOD(senderReplaceTrack
         reject(@"E_INVALID", @"Could not get transceive", nil);
     }
 
-    RTCRtpSender *sender = transceiver.sender;
-    RTCMediaStreamTrack *track = self.localTracks[trackId];
+    LKRTCRtpSender *sender = transceiver.sender;
+    LKRTCMediaStreamTrack *track = self.localTracks[trackId];
     [sender setTrack:track];
     resolve(@true);
 }
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(senderSetParameters
                   : (NSDictionary *)options resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
     if (peerConnection == nil) {
         RCTLogWarn(@"PeerConnection %@ not found in senderSetParameters()", objectID);
@@ -80,8 +80,8 @@ RCT_EXPORT_METHOD(senderSetParameters
         return;
     }
 
-    RTCRtpTransceiver *transceiver = nil;
-    for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+    LKRTCRtpTransceiver *transceiver = nil;
+    for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
         if ([senderId isEqual:t.sender.senderId]) {
             transceiver = t;
             break;
@@ -94,8 +94,8 @@ RCT_EXPORT_METHOD(senderSetParameters
         return;
     }
 
-    RTCRtpSender *sender = transceiver.sender;
-    RTCRtpParameters *parameters = sender.parameters;
+    LKRTCRtpSender *sender = transceiver.sender;
+    LKRTCRtpParameters *parameters = sender.parameters;
     [sender setParameters:[self updateParametersWithOptions:options params:parameters]];
 
     resolve([SerializeUtils parametersToJSON:sender.parameters]);
@@ -107,7 +107,7 @@ RCT_EXPORT_METHOD(transceiverSetDirection
                   : (NSString *)direction resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
     if (peerConnection == nil) {
         RCTLogWarn(@"transceiverSetDirection() PeerConnection %@ not found in transceiverSetDirection()", objectID);
@@ -115,8 +115,8 @@ RCT_EXPORT_METHOD(transceiverSetDirection
         return;
     }
 
-    RTCRtpTransceiver *transceiver = nil;
-    for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+    LKRTCRtpTransceiver *transceiver = nil;
+    for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
         if ([senderId isEqual:t.sender.senderId]) {
             transceiver = t;
             break;
@@ -144,7 +144,7 @@ RCT_EXPORT_METHOD(transceiverStop
                   : (NSString *)senderId resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
     if (peerConnection == nil) {
         RCTLogWarn(@"PeerConnection %@ not found in transceiverStop()", objectID);
@@ -152,8 +152,8 @@ RCT_EXPORT_METHOD(transceiverStop
         return;
     }
 
-    RTCRtpTransceiver *transceiver = nil;
-    for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+    LKRTCRtpTransceiver *transceiver = nil;
+    for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
         if ([senderId isEqual:t.sender.senderId]) {
             transceiver = t;
             break;
@@ -175,15 +175,15 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(transceiverSetCodecPreferences
                                        : (nonnull NSNumber *)objectID senderId
                                        : (NSString *)senderId codecPreferences
                                        : (NSArray *)codecPreferences) {
-    RTCPeerConnection *peerConnection = self.peerConnections[objectID];
+    LKRTCPeerConnection *peerConnection = self.peerConnections[objectID];
 
     if (peerConnection == nil) {
         RCTLogWarn(@"PeerConnection %@ not found in transceiverSetCodecPreferences()", objectID);
         return nil;
     }
 
-    RTCRtpTransceiver *transceiver = nil;
-    for (RTCRtpTransceiver *t in peerConnection.transceivers) {
+    LKRTCRtpTransceiver *transceiver = nil;
+    for (LKRTCRtpTransceiver *t in peerConnection.transceivers) {
         if ([senderId isEqual:t.sender.senderId]) {
             transceiver = t;
             break;
@@ -196,12 +196,12 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(transceiverSetCodecPreferences
     }
 
     // Get the available codecs
-    RTCRtpTransceiverDirection direction = transceiver.direction;
+    LKRTCRtpTransceiverDirection direction = transceiver.direction;
     NSMutableArray *availableCodecs = [NSMutableArray new];
-    NSString *kind = transceiver.mediaType == RTCRtpMediaTypeAudio ? @"audio" : @"video";
-    if (direction == RTCRtpTransceiverDirectionSendRecv || direction == RTCRtpTransceiverDirectionSendOnly) {
-        RTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpSenderCapabilitiesForKind:kind];
-        for (RTCRtpCodecCapability *codec in capabilities.codecs) {
+    NSString *kind = transceiver.mediaType == LKRTCRtpMediaTypeAudio ? @"audio" : @"video";
+    if (direction == LKRTCRtpTransceiverDirectionSendRecv || direction == LKRTCRtpTransceiverDirectionSendOnly) {
+        LKRTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpSenderCapabilitiesForKind:kind];
+        for (LKRTCRtpCodecCapability *codec in capabilities.codecs) {
             NSDictionary *codecDict = [SerializeUtils codecCapabilityToJSON:codec];
             [availableCodecs addObject:@{
                 @"dict" : codecDict,
@@ -209,9 +209,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(transceiverSetCodecPreferences
             }];
         }
     }
-    if (direction == RTCRtpTransceiverDirectionSendRecv || direction == RTCRtpTransceiverDirectionRecvOnly) {
-        RTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpReceiverCapabilitiesForKind:kind];
-        for (RTCRtpCodecCapability *codec in capabilities.codecs) {
+    if (direction == LKRTCRtpTransceiverDirectionSendRecv || direction == LKRTCRtpTransceiverDirectionRecvOnly) {
+        LKRTCRtpCapabilities *capabilities = [self.peerConnectionFactory rtpReceiverCapabilitiesForKind:kind];
+        for (LKRTCRtpCodecCapability *codec in capabilities.codecs) {
             NSDictionary *codecDict = [SerializeUtils codecCapabilityToJSON:codec];
             [availableCodecs addObject:@{
                 @"dict" : codecDict,
@@ -238,7 +238,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(transceiverSetCodecPreferences
     return nil;
 }
 
-- (RTCRtpParameters *)updateParametersWithOptions:(NSDictionary *)options params:(RTCRtpParameters *)params {
+- (LKRTCRtpParameters *)updateParametersWithOptions:(NSDictionary *)options params:(LKRTCRtpParameters *)params {
     NSArray *encodingsArray = options[@"encodings"];
     NSArray *encodings = params.encodings;
 
@@ -248,7 +248,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(transceiverSetCodecPreferences
 
     for (int i = 0; i < [encodingsArray count]; i++) {
         NSDictionary *encodingUpdate = encodingsArray[i];
-        RTCRtpEncodingParameters *encoding = encodings[i];
+        LKRTCRtpEncodingParameters *encoding = encodings[i];
 
         encoding.isActive = [encodingUpdate[@"active"] boolValue];
         encoding.rid = encodingUpdate[@"rid"];

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.h
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.h
@@ -1,12 +1,12 @@
 
-#import <WebRTC/RTCPeerConnection.h>
+#import <LiveKitWebRTC/RTCPeerConnection.h>
 #import "WebRTCModule.h"
 
-@interface RTCPeerConnection (VideoTrackAdapter)
+@interface LKRTCPeerConnection (VideoTrackAdapter)
 
 @property(nonatomic, strong) NSMutableDictionary<NSString *, id> *videoTrackAdapters;
 
-- (void)addVideoTrackAdapter:(RTCVideoTrack *)track;
-- (void)removeVideoTrackAdapter:(RTCVideoTrack *)track;
+- (void)addVideoTrackAdapter:(LKRTCVideoTrack *)track;
+- (void)removeVideoTrackAdapter:(LKRTCVideoTrack *)track;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
+++ b/ios/RCTWebRTC/WebRTCModule+VideoTrackAdapter.m
@@ -8,8 +8,8 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTLog.h>
 
-#import <WebRTC/RTCVideoRenderer.h>
-#import <WebRTC/RTCVideoTrack.h>
+#import <LiveKitWebRTC/RTCVideoRenderer.h>
+#import <LiveKitWebRTC/RTCVideoTrack.h>
 
 #import "WebRTCModule+RTCPeerConnection.h"
 #import "WebRTCModule+VideoTrackAdapter.h"
@@ -26,7 +26,7 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
  * stalled for the default interval it will emit a mute event. If frames keep
  * being received, the track unmute event will be emitted.
  */
-@interface TrackMuteDetector : NSObject<RTCVideoRenderer>
+@interface TrackMuteDetector : NSObject<LKRTCVideoRenderer>
 
 @property(copy, nonatomic) NSNumber *peerConnectionId;
 @property(copy, nonatomic) NSString *trackId;
@@ -111,17 +111,17 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
     dispatch_resume(_timer);
 }
 
-- (void)renderFrame:(nullable RTCVideoFrame *)frame {
+- (void)renderFrame:(nullable LKRTCVideoFrame *)frame {
     atomic_fetch_add(&_frameCount, 1);
 }
 
 - (void)setSize:(CGSize)size {
-    // XXX unneeded for our purposes, but part of RTCVideoRenderer.
+    // XXX unneeded for our purposes, but part of LKRTCVideoRenderer.
 }
 
 @end
 
-@implementation RTCPeerConnection (VideoTrackAdapter)
+@implementation LKRTCPeerConnection (VideoTrackAdapter)
 
 - (NSMutableDictionary<NSString *, id> *)videoTrackAdapters {
     return objc_getAssociatedObject(self, _cmd);
@@ -132,7 +132,7 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
         self, @selector(videoTrackAdapters), videoTrackAdapters, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)addVideoTrackAdapter:(RTCVideoTrack *)track {
+- (void)addVideoTrackAdapter:(LKRTCVideoTrack *)track {
     NSString *trackId = track.trackId;
     if ([self.videoTrackAdapters objectForKey:trackId] != nil) {
         RCTLogWarn(@"[VideoTrackAdapter] Adapter already exists for track %@", trackId);
@@ -149,7 +149,7 @@ static const NSTimeInterval MUTE_DELAY = 1.5;
     RCTLogTrace(@"[VideoTrackAdapter] Adapter created for track %@", trackId);
 }
 
-- (void)removeVideoTrackAdapter:(RTCVideoTrack *)track {
+- (void)removeVideoTrackAdapter:(LKRTCVideoTrack *)track {
     NSString *trackId = track.trackId;
     TrackMuteDetector *muteDetector = [self.videoTrackAdapters objectForKey:trackId];
     if (muteDetector == nil) {

--- a/ios/RCTWebRTC/WebRTCModule.h
+++ b/ios/RCTWebRTC/WebRTCModule.h
@@ -5,7 +5,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTEventEmitter.h>
 
-#import <WebRTC/WebRTC.h>
+#import <LiveKitWebRTC/LiveKitWebRTC.h>
 
 static NSString *const kEventPeerConnectionSignalingStateChanged = @"peerConnectionSignalingStateChanged";
 static NSString *const kEventPeerConnectionStateChanged = @"peerConnectionStateChanged";
@@ -37,21 +37,21 @@ static NSString *const kEventAudioDeviceModuleDevicesUpdated = @"audioDeviceModu
 
 @property(nonatomic, strong) dispatch_queue_t workerQueue;
 
-@property(nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
-@property(nonatomic, strong) id<RTCVideoDecoderFactory> decoderFactory;
-@property(nonatomic, strong) id<RTCVideoEncoderFactory> encoderFactory;
+@property(nonatomic, strong) LKRTCPeerConnectionFactory *peerConnectionFactory;
+@property(nonatomic, strong) id<LKRTCVideoDecoderFactory> decoderFactory;
+@property(nonatomic, strong) id<LKRTCVideoEncoderFactory> encoderFactory;
 
-@property(nonatomic, strong) NSMutableDictionary<NSNumber *, RTCPeerConnection *> *peerConnections;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStream *> *localStreams;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCMediaStreamTrack *> *localTracks;
+@property(nonatomic, strong) NSMutableDictionary<NSNumber *, LKRTCPeerConnection *> *peerConnections;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCMediaStream *> *localStreams;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCMediaStreamTrack *> *localTracks;
 
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCFrameCryptor *> *frameCryptors;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCFrameCryptorKeyProvider *> *keyProviders;
-@property(nonatomic, strong) NSMutableDictionary<NSString *, RTCDataPacketCryptor *> *dataPacketCryptors;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCFrameCryptor *> *frameCryptors;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCFrameCryptorKeyProvider *> *keyProviders;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, LKRTCDataPacketCryptor *> *dataPacketCryptors;
 
-@property(nonatomic, readonly) RTCAudioDeviceModule *audioDeviceModule;
+@property(nonatomic, readonly) LKRTCAudioDeviceModule *audioDeviceModule;
 @property(nonatomic, strong) AudioDeviceModuleObserver *audioDeviceModuleObserver;
 
-- (RTCMediaStream *)streamForReactTag:(NSString *)reactTag;
+- (LKRTCMediaStream *)streamForReactTag:(NSString *)reactTag;
 
 @end

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -28,7 +28,7 @@
     _localStreams = nil;
 
     for (NSNumber *peerConnectionId in _peerConnections) {
-        RTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];
+        LKRTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];
         peerConnection.delegate = nil;
         [peerConnection close];
     }
@@ -41,29 +41,29 @@
     self = [super init];
     if (self) {
         WebRTCModuleOptions *options = [WebRTCModuleOptions sharedInstance];
-        id<RTCAudioDevice> audioDevice = options.audioDevice;
-        id<RTCVideoDecoderFactory> decoderFactory = options.videoDecoderFactory;
-        id<RTCVideoEncoderFactory> encoderFactory = options.videoEncoderFactory;
-        id<RTCAudioProcessingModule> audioProcessingModule = options.audioProcessingModule;
+        id<LKRTCAudioDevice> audioDevice = options.audioDevice;
+        id<LKRTCVideoDecoderFactory> decoderFactory = options.videoDecoderFactory;
+        id<LKRTCVideoEncoderFactory> encoderFactory = options.videoEncoderFactory;
+        id<LKRTCAudioProcessingModule> audioProcessingModule = options.audioProcessingModule;
         NSDictionary *fieldTrials = options.fieldTrials;
-        RTCLoggingSeverity loggingSeverity = options.loggingSeverity;
+        LKRTCLoggingSeverity loggingSeverity = options.loggingSeverity;
 
         // Initialize field trials.
         if (fieldTrials == nil) {
             // Fix for dual-sim connectivity:
             // https://bugs.chromium.org/p/webrtc/issues/detail?id=10966
-            fieldTrials = @{kRTCFieldTrialUseNWPathMonitor : kRTCFieldTrialEnabledValue};
+            fieldTrials = @{kLKRTCFieldTrialUseNWPathMonitor : kLKRTCFieldTrialEnabledValue};
         }
-        RTCInitFieldTrialDictionary(fieldTrials);
+        LKRTCInitFieldTrialDictionary(fieldTrials);
 
         // Initialize logging.
-        RTCSetMinDebugLogLevel(loggingSeverity);
+        LKRTCSetMinDebugLogLevel(loggingSeverity);
 
         if (encoderFactory == nil) {
-            encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
+            encoderFactory = [[LKRTCDefaultVideoEncoderFactory alloc] init];
         }
         if (decoderFactory == nil) {
-            decoderFactory = [[RTCDefaultVideoDecoderFactory alloc] init];
+            decoderFactory = [[LKRTCDefaultVideoDecoderFactory alloc] init];
         }
         _encoderFactory = encoderFactory;
         _decoderFactory = decoderFactory;
@@ -74,14 +74,14 @@
         if (audioDevice == nil) {
             RCTLogInfo(@"Using audio processing module: %@", NSStringFromClass([audioProcessingModule class]));
             _peerConnectionFactory =
-                [[RTCPeerConnectionFactory alloc] initWithAudioDeviceModuleType:RTCAudioDeviceModuleTypeAudioEngine
+                [[LKRTCPeerConnectionFactory alloc] initWithAudioDeviceModuleType:LKRTCAudioDeviceModuleTypeAudioEngine
                                                           bypassVoiceProcessing:NO
                                                                  encoderFactory:encoderFactory
                                                                  decoderFactory:decoderFactory
                                                           audioProcessingModule:audioProcessingModule];
         } else {
             RCTLogInfo(@"Using audio device: %@", NSStringFromClass([audioDevice class]));
-            _peerConnectionFactory = [[RTCPeerConnectionFactory alloc] initWithEncoderFactory:encoderFactory
+            _peerConnectionFactory = [[LKRTCPeerConnectionFactory alloc] initWithEncoderFactory:encoderFactory
                                                                                decoderFactory:decoderFactory
                                                                                   audioDevice:audioDevice];
         }
@@ -106,11 +106,11 @@
     return self;
 }
 
-- (RTCMediaStream *)streamForReactTag:(NSString *)reactTag {
-    RTCMediaStream *stream = _localStreams[reactTag];
+- (LKRTCMediaStream *)streamForReactTag:(NSString *)reactTag {
+    LKRTCMediaStream *stream = _localStreams[reactTag];
     if (!stream) {
         for (NSNumber *peerConnectionId in _peerConnections) {
-            RTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];
+            LKRTCPeerConnection *peerConnection = _peerConnections[peerConnectionId];
             stream = peerConnection.remoteStreams[reactTag];
             if (stream) {
                 break;

--- a/ios/RCTWebRTC/WebRTCModuleOptions.h
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.h
@@ -1,16 +1,16 @@
 #import <Foundation/Foundation.h>
-#import <WebRTC/WebRTC.h>
+#import <LiveKitWebRTC/LiveKitWebRTC.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WebRTCModuleOptions : NSObject
 
-@property(nonatomic, strong, nullable) id<RTCVideoDecoderFactory> videoDecoderFactory;
-@property(nonatomic, strong, nullable) id<RTCVideoEncoderFactory> videoEncoderFactory;
-@property(nonatomic, strong, nullable) id<RTCAudioDevice> audioDevice;
-@property(nonatomic, strong, nullable) id<RTCAudioProcessingModule> audioProcessingModule;
+@property(nonatomic, strong, nullable) id<LKRTCVideoDecoderFactory> videoDecoderFactory;
+@property(nonatomic, strong, nullable) id<LKRTCVideoEncoderFactory> videoEncoderFactory;
+@property(nonatomic, strong, nullable) id<LKRTCAudioDevice> audioDevice;
+@property(nonatomic, strong, nullable) id<LKRTCAudioProcessingModule> audioProcessingModule;
 @property(nonatomic, strong, nullable) NSDictionary *fieldTrials;
-@property(nonatomic, assign) RTCLoggingSeverity loggingSeverity;
+@property(nonatomic, assign) LKRTCLoggingSeverity loggingSeverity;
 @property(nonatomic, assign) BOOL enableMultitaskingCameraAccess;
 
 @property(nonatomic, assign) double defaultTrackVolume;

--- a/ios/RCTWebRTC/WebRTCModuleOptions.m
+++ b/ios/RCTWebRTC/WebRTCModuleOptions.m
@@ -21,7 +21,7 @@
         self.fieldTrials = nil;
         self.videoEncoderFactory = nil;
         self.videoDecoderFactory = nil;
-        self.loggingSeverity = RTCLoggingSeverityNone;
+        self.loggingSeverity = LKRTCLoggingSeverityNone;
         self.defaultTrackVolume = 1.0;
     }
 

--- a/ios/RCTWebRTC/videoEffects/VideoEffectProcessor.h
+++ b/ios/RCTWebRTC/videoEffects/VideoEffectProcessor.h
@@ -1,13 +1,13 @@
-#import <WebRTC/RTCVideoSource.h>
+#import <LiveKitWebRTC/RTCVideoSource.h>
 
 #import "VideoFrameProcessor.h"
 
-@interface VideoEffectProcessor : NSObject<RTCVideoCapturerDelegate>
+@interface VideoEffectProcessor : NSObject<LKRTCVideoCapturerDelegate>
 
 @property(nonatomic, strong) NSArray<NSObject<VideoFrameProcessorDelegate> *> *videoFrameProcessors;
-@property(nonatomic, strong) RTCVideoSource *videoSource;
+@property(nonatomic, strong) LKRTCVideoSource *videoSource;
 
 - (instancetype)initWithProcessors:(NSArray<NSObject<VideoFrameProcessorDelegate> *> *)videoFrameProcessors
-                       videoSource:(RTCVideoSource *)videoSource;
+                       videoSource:(LKRTCVideoSource *)videoSource;
 
 @end

--- a/ios/RCTWebRTC/videoEffects/VideoEffectProcessor.m
+++ b/ios/RCTWebRTC/videoEffects/VideoEffectProcessor.m
@@ -1,19 +1,19 @@
-#import <WebRTC/RTCVideoCapturer.h>
+#import <LiveKitWebRTC/RTCVideoCapturer.h>
 
 #import "VideoEffectProcessor.h"
 
 @implementation VideoEffectProcessor
 
 - (instancetype)initWithProcessors:(NSArray<NSObject<VideoFrameProcessorDelegate> *> *)videoFrameProcessors
-                       videoSource:(RTCVideoSource *)videoSource {
+                       videoSource:(LKRTCVideoSource *)videoSource {
     self = [super init];
     _videoFrameProcessors = videoFrameProcessors;
     _videoSource = videoSource;
     return self;
 }
 
-- (void)capturer:(nonnull RTCVideoCapturer *)capturer didCaptureVideoFrame:(nonnull RTCVideoFrame *)frame {
-    RTCVideoFrame *processedFrame = frame;
+- (void)capturer:(nonnull LKRTCVideoCapturer *)capturer didCaptureVideoFrame:(nonnull LKRTCVideoFrame *)frame {
+    LKRTCVideoFrame *processedFrame = frame;
     for (NSObject<VideoFrameProcessorDelegate> *processor in _videoFrameProcessors) {
         processedFrame = [processor capturer:capturer didCaptureVideoFrame:processedFrame];
     }

--- a/ios/RCTWebRTC/videoEffects/VideoFrameProcessor.h
+++ b/ios/RCTWebRTC/videoEffects/VideoFrameProcessor.h
@@ -1,8 +1,8 @@
-#import <WebRTC/RTCVideoCapturer.h>
-#import <WebRTC/RTCVideoFrame.h>
+#import <LiveKitWebRTC/RTCVideoCapturer.h>
+#import <LiveKitWebRTC/RTCVideoFrame.h>
 
 @protocol VideoFrameProcessorDelegate
 
-- (RTCVideoFrame *)capturer:(RTCVideoCapturer *)capturer didCaptureVideoFrame:(RTCVideoFrame *)frame;
+- (LKRTCVideoFrame *)capturer:(LKRTCVideoCapturer *)capturer didCaptureVideoFrame:(LKRTCVideoFrame *)frame;
 
 @end

--- a/livekit-react-native-webrtc.podspec
+++ b/livekit-react-native-webrtc.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.libraries           = 'c', 'sqlite3', 'stdc++'
   s.framework           = 'AudioToolbox','AVFoundation', 'CoreAudio', 'CoreGraphics', 'CoreVideo', 'GLKit', 'VideoToolbox'
   s.dependency          'React-Core'
-  s.dependency          'WebRTC-SDK', '=144.7559.10'
+  s.dependency          'LiveKitWebRTC', '=144.7559.10'
   
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
## Switch iOS dependency from WebRTC-SDK to LiveKitWebRTC to resolve CocoaPods framework conflicts

### Problem

When using `livekit-react-native-webrtc` alongside other WebRTC-based SDKs `pod install` fails with:

```
[!] The 'Pods-XYZ' target has frameworks with conflicting names: webrtc.xcframework.
```

Both `WebRTC-SDK` and `JitsiWebRTC` vendor a framework named `webrtc.xcframework`, and CocoaPods refuses to integrate two frameworks with the same filename into the same target.

Related: https://github.com/livekit/livekit/issues/2809

### Solution

Switch the iOS CocoaPods dependency from `WebRTC-SDK` to `LiveKitWebRTC` — LiveKit's own repackaged WebRTC build from [`livekit/webrtc-xcframework`](https://github.com/livekit/webrtc-xcframework). This is the same WebRTC codebase (same version `144.7559.10`) but:

- Vendored as `LiveKitWebRTC.xcframework` (no filename collision)
- Objective-C symbols are prefixed with `LK` (e.g., `RTCPeerConnection` → `LKRTCPeerConnection`, no linker-level collisions)

This matches what `client-sdk-swift` already does — it depends on `LiveKitWebRTC`, not `WebRTC-SDK`.

### Changes

- **Podspec**: `WebRTC-SDK` → `LiveKitWebRTC` dependency
- **All `ios/` ObjC sources**:
  - `#import <WebRTC/...>` → `#import <LiveKitWebRTC/...>`
  - `#import <LiveKitWebRTC/WebRTC.h>` → `#import <LiveKitWebRTC/LiveKitWebRTC.h>` (umbrella header renamed)
  - All WebRTC SDK type references prefixed with `LK` (e.g., `RTCPeerConnection` → `LKRTCPeerConnection`)
  - Header filenames in imports unchanged (LiveKitWebRTC keeps original header filenames)
  - Locally-defined types preserved (`RTCVideoView`, `RTCVideoViewManager`, `RTCVideoViewObjectFit`) to maintain JS bridge compatibility

### No JS-side changes required

The native module name (`WebRTCModule`) and native view name (`RTCVideoView`) are unchanged, so no changes to the TypeScript/JavaScript layer are needed.
