### PR TITLE
feat(ios): configure the default audio session natively in the observer

### DIFF
--- a/.github/workflows/ios_ci.yml
+++ b/.github/workflows/ios_ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   ios-compile:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.h
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.h
@@ -18,6 +18,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, assign) BOOL isDidDisableEngineActive;
 @property(atomic, assign) BOOL isWillReleaseEngineActive;
 
+// Native default audio-session configuration policy. When set (non-nil) and no
+// custom JS handler is registered for willEnable/didDisable, the observer
+// configures the AVAudioSession natively on the worker thread instead of doing a
+// JS round trip. Pushed once from JS, and nil disables it. Reassigning the policy
+// is safe at any time: activation state is tracked against RTCAudioSession
+// itself, not against the policy. Shape:
+//   @{ @"recording": <cfg>, @"playout": <cfg>, @"deactivateOnStop": @(BOOL) }
+// where <cfg> is @{ @"audioCategory": str, @"audioMode": str,
+//                   @"audioCategoryOptions": @[str...] }.
+@property(atomic, copy, nullable) NSDictionary *automaticAudioSessionConfig;
+
 // Methods to receive results from JS. requestId echoes the id sent with the
 // corresponding event so stale responses from timed-out rounds can be dropped.
 - (void)resolveEngineCreatedWithRequestId:(NSInteger)requestId result:(NSInteger)result;

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.h
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.h
@@ -21,9 +21,19 @@ NS_ASSUME_NONNULL_BEGIN
 // Native default audio-session configuration policy. When set (non-nil) and no
 // custom JS handler is registered for willEnable/didDisable, the observer
 // configures the AVAudioSession natively on the worker thread instead of doing a
-// JS round trip. Pushed once from JS, and nil disables it. Reassigning the policy
-// is safe at any time: activation state is tracked against RTCAudioSession
-// itself, not against the policy. Shape:
+// JS round trip. Pushed once from JS, and nil disables it. Reassigning or
+// clearing the policy is safe: activation state is tracked against
+// RTCAudioSession itself, not against the policy, and a hold orphaned by
+// clearing is released at the next full stop. One consequence: clearing a
+// deactivateOnStop:NO policy while the engine is already stopped keeps the
+// session activation held (and the OS session active) until the next engine
+// cycle, because no callback fires in between. Callers who need an immediate
+// release should stop under a deactivateOnStop:YES policy before clearing.
+//
+// Precedence is evaluated per hook, so custom willEnable and didDisable JS
+// handlers must be registered or cleared as a pair while a policy is set. A JS
+// handler owning one hook while the native policy owns the other can activate a
+// session that the owning regime never releases. Shape:
 //   @{ @"recording": <cfg>, @"playout": <cfg>, @"deactivateOnStop": @(BOOL) }
 // where <cfg> is @{ @"audioCategory": str, @"audioMode": str,
 //                   @"audioCategoryOptions": @[str...] }.

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.h
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.h
@@ -11,6 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 // immediately without a JS round trip, avoiding the deadlock window entirely.
 // Atomic because they are written on the JS thread (handler registration) and
 // read on the native audio thread (delegate callbacks).
+//
+// Warnings:
+// - Clear willEnable/didDisable JS handlers as a pair while a policy is set;
+//  mixed ownership can activate a session that nothing releases.
 @property(atomic, assign) BOOL isEngineCreatedActive;
 @property(atomic, assign) BOOL isWillEnableEngineActive;
 @property(atomic, assign) BOOL isWillStartEngineActive;
@@ -18,25 +22,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, assign) BOOL isDidDisableEngineActive;
 @property(atomic, assign) BOOL isWillReleaseEngineActive;
 
-// Native default audio-session configuration policy. When set (non-nil) and no
-// custom JS handler is registered for willEnable/didDisable, the observer
-// configures the AVAudioSession natively on the worker thread instead of doing a
-// JS round trip. Pushed once from JS, and nil disables it. Reassigning or
-// clearing the policy is safe: activation state is tracked against
-// RTCAudioSession itself, not against the policy, and a hold orphaned by
-// clearing is released at the next full stop. One consequence: clearing a
-// deactivateOnStop:NO policy while the engine is already stopped keeps the
-// session activation held (and the OS session active) until the next engine
-// cycle, because no callback fires in between. Callers who need an immediate
-// release should stop under a deactivateOnStop:YES policy before clearing.
-//
-// Precedence is evaluated per hook, so custom willEnable and didDisable JS
-// handlers must be registered or cleared as a pair while a policy is set. A JS
-// handler owning one hook while the native policy owns the other can activate a
-// session that the owning regime never releases. Shape:
-//   @{ @"recording": <cfg>, @"playout": <cfg>, @"deactivateOnStop": @(BOOL) }
+// Native default AVAudioSession policy. When non-nil and no JS willEnable/
+// didDisable handler is registered, applied on the worker thread. nil clears it.
+// Shape: @{ @"recording": <cfg>, @"playout": <cfg>, @"deactivateOnStop": @(BOOL) }
 // where <cfg> is @{ @"audioCategory": str, @"audioMode": str,
 //                   @"audioCategoryOptions": @[str...] }.
+//
+// Warnings:
+// - Clearing a deactivateOnStop:NO policy while the engine is already stopped
+//   keeps the activation held until the next engine cycle. For an immediate
+//   release, stop under deactivateOnStop:YES before clearing.
 @property(atomic, copy, nullable) NSDictionary *automaticAudioSessionConfig;
 
 // Methods to receive results from JS. requestId echoes the id sent with the

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -20,6 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 // outcome is deliberately preferred over the unrecoverable deadlock.
 static const int64_t kJSResponseTimeoutSeconds = 2;
 
+// Returned from willEnable/didDisable when native automatic audio-session
+// configuration fails, so libwebrtc rolls the engine operation back. Mirrors the
+// SDK's kAudioEngineErrorFailedToConfigureAudioSession value.
+static const NSInteger kAutomaticAudioSessionConfigError = -4100;
+
 static os_log_t ADMObserverLog(void) {
     static os_log_t log;
     static dispatch_once_t onceToken;
@@ -54,6 +59,15 @@ static os_log_t ADMObserverLog(void) {
 // runs on the native audio thread and the resolve side on the JS thread.
 @property(nonatomic, assign) NSInteger requestIdSeq;
 @property(nonatomic, assign) NSInteger awaitingRequestId;
+
+// Whether the native auto-config path currently holds an
+// RTCAudioSession activation. RTCAudioSession reference-counts activations
+// (setActive:YES on an already-active session only bumps the count, and
+// setActive:NO only deactivates at count 1), so the observer must activate at
+// most once per hold and release exactly what it took, or the OS session leaks
+// active forever. Only touched on the serial delegate (worker) thread, and kept
+// atomic as cheap insurance against future cross-thread reads.
+@property(atomic, assign) BOOL autoSessionHoldsActivation;
 
 @end
 
@@ -185,6 +199,14 @@ static os_log_t ADMObserverLog(void) {
               willEnableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
+    // With no custom JS handler registered, configure the audio session natively
+    // here instead of doing a JS round trip. This is the default path and avoids
+    // parking the audio worker thread on the JS thread entirely. A custom handler
+    // (isWillEnableEngineActive == YES) falls through to the bounded round trip.
+    if (!self.isWillEnableEngineActive && self.automaticAudioSessionConfig != nil) {
+        return [self applyAutomaticAudioSessionConfigForPlayout:isPlayoutEnabled recording:isRecordingEnabled];
+    }
+
     BOOL isActive = self.isWillEnableEngineActive;
 
     if (isActive) {
@@ -276,6 +298,13 @@ static os_log_t ADMObserverLog(void) {
               didDisableEngine:(AVAudioEngine *)engine
               isPlayoutEnabled:(BOOL)isPlayoutEnabled
             isRecordingEnabled:(BOOL)isRecordingEnabled {
+    // Counterpart of willEnable - apply the native session policy (here the
+    // deactivate-on-stop edge) without a JS round trip when no custom handler
+    // is registered.
+    if (!self.isDidDisableEngineActive && self.automaticAudioSessionConfig != nil) {
+        return [self applyAutomaticAudioSessionConfigForPlayout:isPlayoutEnabled recording:isRecordingEnabled];
+    }
+
     BOOL isActive = self.isDidDisableEngineActive;
 
     if (isActive) {
@@ -417,6 +446,135 @@ static os_log_t ADMObserverLog(void) {
                          self.willReleaseEngineResult = result;
                      }
                  semaphore:self.willReleaseEngineSemaphore];
+}
+
+#pragma mark - Native automatic audio session configuration
+
+// Applies the pushed audio-session policy on the worker thread with no JS round
+// trip: configures on every active state, activates when the session is not
+// already active, optionally deactivates on stop, and returns a non-zero error
+// code on failure so libwebrtc rolls the operation back.
+//
+// Activation is decided against RTCAudioSession's own state rather than a mirror
+// of past engine states, so a policy re-push mid-call (setupIOSAudioManagement
+// called again), a path switch, or an interruption cannot desync it:
+// - session already active (previous hold, custom JS path, or the app) ->
+//   reconfigure only, never a second refcounted activation.
+// - session inactive (fresh start, or the custom path deactivated it before a
+//   switch back to the native path) -> activate and take the hold.
+- (NSInteger)applyAutomaticAudioSessionConfigForPlayout:(BOOL)isPlayoutEnabled recording:(BOOL)isRecordingEnabled {
+    NSDictionary *policy = self.automaticAudioSessionConfig;
+    if (policy == nil) {
+        return 0;
+    }
+
+    BOOL nowActive = isPlayoutEnabled || isRecordingEnabled;
+
+    RTCAudioSession *session = [RTCAudioSession sharedInstance];
+    [session lockForConfiguration];
+
+    NSError *error = nil;
+    if (!nowActive) {
+        if (self.autoSessionHoldsActivation && [policy[@"deactivateOnStop"] boolValue]) {
+            os_log_debug(ADMObserverLog(), "Native auto-config: deactivating audio session");
+            [session setActive:NO error:&error];
+            // RTCAudioSession decrements its activation count even when the OS
+            // session is already inactive (e.g. an interruption cleared it) or the
+            // call fails, so the hold is released in every outcome.
+            self.autoSessionHoldsActivation = NO;
+        }
+    } else {
+        // Recording uses the duplex (playAndRecord) config, while playout-only uses
+        // the playback config. Both are supplied by the SDK in automaticAudioSessionConfig.
+        NSDictionary *cfg = isRecordingEnabled ? policy[@"recording"] : policy[@"playout"];
+        RTCAudioSessionConfiguration *rtcConfig = [RTCAudioSessionConfiguration webRTCConfiguration];
+        if (cfg[@"audioCategory"] != nil) {
+            rtcConfig.category = [self avAudioSessionCategoryFromString:cfg[@"audioCategory"]];
+        }
+        if (cfg[@"audioMode"] != nil) {
+            rtcConfig.mode = [self avAudioSessionModeFromString:cfg[@"audioMode"]];
+        }
+        if (cfg[@"audioCategoryOptions"] != nil) {
+            rtcConfig.categoryOptions = [self avAudioSessionCategoryOptionsFromStrings:cfg[@"audioCategoryOptions"]];
+        }
+        os_log_debug(ADMObserverLog(), "Native auto-config: setting category %{public}@", rtcConfig.category);
+        [session setConfiguration:rtcConfig error:&error];
+        if (error == nil && !session.isActive) {
+            os_log_debug(ADMObserverLog(), "Native auto-config: activating audio session");
+            [session setActive:YES error:&error];
+            if (error == nil) {
+                self.autoSessionHoldsActivation = YES;
+            }
+        }
+    }
+
+    [session unlockForConfiguration];
+
+    if (error != nil) {
+        os_log_error(ADMObserverLog(), "Native auto-config failed: %{public}@", error.localizedDescription);
+        return kAutomaticAudioSessionConfigError;
+    }
+
+    return 0;
+}
+
+// TODO: this friendly-string -> AVAudioSession mapping mirrors AudioUtils in the
+// LiveKit React Native SDK. Keep the accepted values in sync, or consolidate by
+// pushing raw AVAudioSession values across the bridge instead.
+- (NSString *)avAudioSessionCategoryFromString:(NSString *)value {
+    static NSDictionary<NSString *, NSString *> *map;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        map = @{
+            @"ambient" : AVAudioSessionCategoryAmbient,
+            @"soloAmbient" : AVAudioSessionCategorySoloAmbient,
+            @"playback" : AVAudioSessionCategoryPlayback,
+            @"record" : AVAudioSessionCategoryRecord,
+            @"playAndRecord" : AVAudioSessionCategoryPlayAndRecord,
+            @"multiRoute" : AVAudioSessionCategoryMultiRoute,
+        };
+    });
+    return map[value] ?: AVAudioSessionCategoryPlayAndRecord;
+}
+
+- (NSString *)avAudioSessionModeFromString:(NSString *)value {
+    static NSDictionary<NSString *, NSString *> *map;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        map = @{
+            @"default" : AVAudioSessionModeDefault,
+            @"voiceChat" : AVAudioSessionModeVoiceChat,
+            @"videoChat" : AVAudioSessionModeVideoChat,
+            @"gameChat" : AVAudioSessionModeGameChat,
+            @"videoRecording" : AVAudioSessionModeVideoRecording,
+            @"measurement" : AVAudioSessionModeMeasurement,
+            @"moviePlayback" : AVAudioSessionModeMoviePlayback,
+            @"spokenAudio" : AVAudioSessionModeSpokenAudio,
+        };
+    });
+    return map[value] ?: AVAudioSessionModeDefault;
+}
+
+- (AVAudioSessionCategoryOptions)avAudioSessionCategoryOptionsFromStrings:(NSArray<NSString *> *)options {
+    AVAudioSessionCategoryOptions result = 0;
+    for (NSString *option in options) {
+        if ([option isEqualToString:@"mixWithOthers"]) {
+            result |= AVAudioSessionCategoryOptionMixWithOthers;
+        } else if ([option isEqualToString:@"duckOthers"]) {
+            result |= AVAudioSessionCategoryOptionDuckOthers;
+        } else if ([option isEqualToString:@"allowBluetooth"]) {
+            result |= AVAudioSessionCategoryOptionAllowBluetooth;
+        } else if ([option isEqualToString:@"allowBluetoothA2DP"]) {
+            result |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+        } else if ([option isEqualToString:@"allowAirPlay"]) {
+            result |= AVAudioSessionCategoryOptionAllowAirPlay;
+        } else if ([option isEqualToString:@"defaultToSpeaker"]) {
+            result |= AVAudioSessionCategoryOptionDefaultToSpeaker;
+        } else if ([option isEqualToString:@"interruptSpokenAudioAndMixWithOthers"]) {
+            result |= AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers;
+        }
+    }
+    return result;
 }
 
 @end

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -625,6 +625,7 @@ static os_log_t ADMObserverLog(void) {
             @"measurement" : AVAudioSessionModeMeasurement,
             @"moviePlayback" : AVAudioSessionModeMoviePlayback,
             @"spokenAudio" : AVAudioSessionModeSpokenAudio,
+            @"voicePrompt" : AVAudioSessionModeVoicePrompt,
         };
     });
     return map[value] ?: AVAudioSessionModeDefault;

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -305,7 +305,20 @@ static os_log_t ADMObserverLog(void) {
     // at the next full stop instead of leaking.
     if (!self.isDidDisableEngineActive &&
         (self.automaticAudioSessionConfig != nil || self.autoSessionHoldsActivation)) {
-        return [self applyAutomaticAudioSessionConfigForPlayout:isPlayoutEnabled recording:isRecordingEnabled];
+        NSInteger result = [self applyAutomaticAudioSessionConfigForPlayout:isPlayoutEnabled
+                                                                  recording:isRecordingEnabled];
+        if (result != 0) {
+            // didDisable fires after the engine's disable work has already run, so
+            // libwebrtc cannot roll this operation back. Propagating an error here
+            // (e.g. a failed reconfigure on a duplex to playout transition) would
+            // only desync its logical engine state from hardware that has already
+            // changed. Log and report the operation as completed. Only willEnable
+            // propagates configuration and activation errors, where the enable has
+            // not happened yet and a rollback is still meaningful.
+            os_log_error(
+                ADMObserverLog(), "Native auto-config: error %ld in didDisable treated as completed", (long)result);
+        }
+        return 0;
     }
 
     BOOL isActive = self.isDidDisableEngineActive;
@@ -499,11 +512,22 @@ static os_log_t ADMObserverLog(void) {
     if (!nowActive) {
         if (self.autoSessionHoldsActivation && [policy[@"deactivateOnStop"] boolValue]) {
             os_log_debug(ADMObserverLog(), "Native auto-config: deactivating audio session");
-            [session setActive:NO error:&error];
+            NSError *deactivateError = nil;
+            [session setActive:NO error:&deactivateError];
             // RTCAudioSession decrements its activation count even when the OS
             // session is already inactive (e.g. an interruption cleared it) or the
             // call fails, so the hold is released in every outcome.
             self.autoSessionHoldsActivation = NO;
+            if (deactivateError != nil) {
+                // Deliberately not propagated. By the time didDisable fires the
+                // engine's disable work is already done and the activation count is
+                // already released, so libwebrtc has nothing it could roll back. A
+                // non-zero return would only desync its logical engine state from
+                // hardware that is already stopped.
+                os_log_error(ADMObserverLog(),
+                             "Native auto-config: deactivation failed (continuing): %{public}@",
+                             deactivateError.localizedDescription);
+            }
         }
     } else {
         // Recording uses the duplex (playAndRecord) config, while playout-only uses

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -500,10 +500,39 @@ static os_log_t ADMObserverLog(void) {
         os_log_debug(ADMObserverLog(), "Native auto-config: setting category %{public}@", rtcConfig.category);
         [session setConfiguration:rtcConfig error:&error];
         if (error == nil && !session.isActive) {
+            BOOL hadHold = self.autoSessionHoldsActivation;
             os_log_debug(ADMObserverLog(), "Native auto-config: activating audio session");
             [session setActive:YES error:&error];
             if (error == nil) {
-                self.autoSessionHoldsActivation = YES;
+                if (hadHold) {
+                    // An interruption or an external deactivation (e.g. CallKit)
+                    // cleared isActive while our activation count was still held, so
+                    // the successful reactivation above stacked a second count onto
+                    // the same hold. Drop the extra count. The drop is a pure
+                    // decrement while the count sits above one, so the session stays
+                    // active.
+                    //
+                    // Ordered activate-first deliberately. Releasing before
+                    // reactivating would zero the count whenever the reactivation
+                    // fails, and RTCAudioSession's interruption-end recovery
+                    // deactivates outright at count zero. A failure must leave the
+                    // prior hold untouched for that recovery to restore it.
+                    os_log_debug(ADMObserverLog(), "Native auto-config: dropping extra count after reactivating");
+                    NSError *dropError = nil;
+                    [session setActive:NO error:&dropError];
+                    if (!session.isActive) {
+                        // The drop deactivated, which means the held count had
+                        // already been consumed by an external unmatched release and
+                        // the drop just gave back the count the reactivation took.
+                        // Reactivate and keep that single fresh count as the hold,
+                        // so even a stale hold converges to a balanced state.
+                        os_log_debug(ADMObserverLog(), "Native auto-config: reactivating after dropping a stale hold");
+                        [session setActive:YES error:&error];
+                    }
+                }
+                if (error == nil) {
+                    self.autoSessionHoldsActivation = YES;
+                }
             }
         }
     }

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -61,12 +61,10 @@ static os_log_t ADMObserverLog(void) {
 @property(nonatomic, assign) NSInteger awaitingRequestId;
 
 // Whether the native auto-config path currently holds an
-// RTCAudioSession activation. RTCAudioSession reference-counts activations
-// (setActive:YES on an already-active session only bumps the count, and
-// setActive:NO only deactivates at count 1), so the observer must activate at
-// most once per hold and release exactly what it took, or the OS session leaks
-// active forever. Only touched on the serial delegate (worker) thread, and kept
-// atomic as cheap insurance against future cross-thread reads.
+// RTCAudioSession activation it must later release. RTCAudioSession refcounts
+// setActive, so a mismatched activate/release leaves the OS session stuck active.
+// Touched only on the serial worker thread; atomic as insurance against future
+// cross-thread reads.
 @property(atomic, assign) BOOL autoSessionHoldsActivation;
 
 @end
@@ -466,10 +464,11 @@ static os_log_t ADMObserverLog(void) {
 
 #pragma mark - Native automatic audio session configuration
 
-// Applies the pushed audio-session policy on the worker thread with no JS round
-// trip: configures on every active state, activates when the session is not
-// already active, optionally deactivates on stop, and returns a non-zero error
-// code on failure so libwebrtc rolls the operation back.
+// Applies the pushed audio-session policy on the worker thread:
+// - configures on every active state,
+// - activates when the session is not
+// - optionally deactivates on stop,
+// - returns a non-zero error code on failure so libwebrtc rolls the operation back.
 //
 // Activation is decided against RTCAudioSession's own state rather than a mirror
 // of past engine states, so a policy re-push mid-call (setupIOSAudioManagement

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -300,8 +300,11 @@ static os_log_t ADMObserverLog(void) {
             isRecordingEnabled:(BOOL)isRecordingEnabled {
     // Counterpart of willEnable - apply the native session policy (here the
     // deactivate-on-stop edge) without a JS round trip when no custom handler
-    // is registered.
-    if (!self.isDidDisableEngineActive && self.automaticAudioSessionConfig != nil) {
+    // is registered. Also entered with a nil policy while an activation hold is
+    // still outstanding, so a hold orphaned by clearing the policy is released
+    // at the next full stop instead of leaking.
+    if (!self.isDidDisableEngineActive &&
+        (self.automaticAudioSessionConfig != nil || self.autoSessionHoldsActivation)) {
         return [self applyAutomaticAudioSessionConfigForPlayout:isPlayoutEnabled recording:isRecordingEnabled];
     }
 
@@ -464,11 +467,30 @@ static os_log_t ADMObserverLog(void) {
 //   switch back to the native path) -> activate and take the hold.
 - (NSInteger)applyAutomaticAudioSessionConfigForPlayout:(BOOL)isPlayoutEnabled recording:(BOOL)isRecordingEnabled {
     NSDictionary *policy = self.automaticAudioSessionConfig;
+    BOOL nowActive = isPlayoutEnabled || isRecordingEnabled;
+
     if (policy == nil) {
+        // The policy was cleared while we still hold an activation (a setup was
+        // torn down mid-call, or a deactivateOnStop:NO policy was abandoned).
+        // Release the orphaned hold at the next full stop so the shared
+        // activation count stays balanced. No configuration is applied because
+        // the native path is disarmed.
+        if (!nowActive && self.autoSessionHoldsActivation) {
+            os_log(ADMObserverLog(), "Native auto-config: releasing orphaned activation hold");
+            RTCAudioSession *session = [RTCAudioSession sharedInstance];
+            [session lockForConfiguration];
+            NSError *releaseError = nil;
+            [session setActive:NO error:&releaseError];
+            self.autoSessionHoldsActivation = NO;
+            [session unlockForConfiguration];
+            if (releaseError != nil) {
+                os_log_error(ADMObserverLog(),
+                             "Native auto-config: orphaned hold release failed (continuing): %{public}@",
+                             releaseError.localizedDescription);
+            }
+        }
         return 0;
     }
-
-    BOOL nowActive = isPlayoutEnabled || isRecordingEnabled;
 
     RTCAudioSession *session = [RTCAudioSession sharedInstance];
     [session lockForConfiguration];

--- a/ios/RCTWebRTC/AudioDeviceModuleObserver.m
+++ b/ios/RCTWebRTC/AudioDeviceModuleObserver.m
@@ -124,7 +124,7 @@ static os_log_t ADMObserverLog(void) {
     if (!isActive) {
         // No handler registered, proceed immediately without JS round trip.
         // This avoids the deadlock window entirely.
-        os_log_debug(ADMObserverLog(), "Skipping JS round-trip for %{public}@ (no handler registered)", eventName);
+        os_log(ADMObserverLog(), "Skipping JS round-trip for %{public}@ (no handler registered)", eventName);
         return 0;
     }
 
@@ -511,7 +511,7 @@ static os_log_t ADMObserverLog(void) {
     NSError *error = nil;
     if (!nowActive) {
         if (self.autoSessionHoldsActivation && [policy[@"deactivateOnStop"] boolValue]) {
-            os_log_debug(ADMObserverLog(), "Native auto-config: deactivating audio session");
+            os_log(ADMObserverLog(), "Native auto-config: deactivating audio session");
             NSError *deactivateError = nil;
             [session setActive:NO error:&deactivateError];
             // RTCAudioSession decrements its activation count even when the OS
@@ -543,11 +543,11 @@ static os_log_t ADMObserverLog(void) {
         if (cfg[@"audioCategoryOptions"] != nil) {
             rtcConfig.categoryOptions = [self avAudioSessionCategoryOptionsFromStrings:cfg[@"audioCategoryOptions"]];
         }
-        os_log_debug(ADMObserverLog(), "Native auto-config: setting category %{public}@", rtcConfig.category);
+        os_log(ADMObserverLog(), "Native auto-config: setting category %{public}@", rtcConfig.category);
         [session setConfiguration:rtcConfig error:&error];
         if (error == nil && !session.isActive) {
             BOOL hadHold = self.autoSessionHoldsActivation;
-            os_log_debug(ADMObserverLog(), "Native auto-config: activating audio session");
+            os_log(ADMObserverLog(), "Native auto-config: activating audio session");
             [session setActive:YES error:&error];
             if (error == nil) {
                 if (hadHold) {
@@ -563,7 +563,7 @@ static os_log_t ADMObserverLog(void) {
                     // fails, and RTCAudioSession's interruption-end recovery
                     // deactivates outright at count zero. A failure must leave the
                     // prior hold untouched for that recovery to restore it.
-                    os_log_debug(ADMObserverLog(), "Native auto-config: dropping extra count after reactivating");
+                    os_log(ADMObserverLog(), "Native auto-config: dropping extra count after reactivating");
                     NSError *dropError = nil;
                     [session setActive:NO error:&dropError];
                     if (!session.isActive) {
@@ -572,7 +572,7 @@ static os_log_t ADMObserverLog(void) {
                         // the drop just gave back the count the reactivation took.
                         // Reactivate and keep that single fresh count as the hold,
                         // so even a stale hold converges to a balanced state.
-                        os_log_debug(ADMObserverLog(), "Native auto-config: reactivating after dropping a stale hold");
+                        os_log(ADMObserverLog(), "Native auto-config: reactivating after dropping a stale hold");
                         [session setActive:YES error:&error];
                     }
                 }

--- a/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.m
+++ b/ios/RCTWebRTC/WebRTCModule+RTCAudioDeviceModule.m
@@ -303,4 +303,15 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetWillReleaseEngineActi
     return nil;
 }
 
+#pragma mark - Automatic Audio Session Configuration
+
+// Pushes the native default audio-session policy (or nil to disable). When set,
+// the observer configures the session natively in willEnable/didDisable instead
+// of doing a JS round trip - removing the JS round trip from the default path.
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(audioDeviceModuleSetAutomaticAudioSessionConfiguration
+                                       : (nullable NSDictionary *)config) {
+    self.audioDeviceModuleObserver.automaticAudioSessionConfig = config;
+    return nil;
+}
+
 @end

--- a/src/AudioDeviceModule.ts
+++ b/src/AudioDeviceModule.ts
@@ -26,10 +26,47 @@ export const AudioEngineAvailability = {
 } as const;
 
 /**
+ * Apple audio session configuration for a single engine state. Matches the
+ * AppleAudioConfiguration shape used by AudioSession.setAppleAudioConfiguration.
+ */
+export interface AutomaticAppleAudioConfiguration {
+  audioCategory?: string;
+  audioMode?: string;
+  audioCategoryOptions?: string[];
+}
+
+/**
+ * Native default audio-session policy. When set, the native observer configures
+ * the AVAudioSession in willEnable/didDisable without a JS round trip.
+ * `recording` is applied while recording is enabled, `playout` while only
+ * playout is enabled, and the session is deactivated on full stop when
+ * `deactivateOnStop` is true.
+ */
+export interface AutomaticAudioSessionConfiguration {
+  recording: AutomaticAppleAudioConfiguration;
+  playout: AutomaticAppleAudioConfiguration;
+  deactivateOnStop: boolean;
+}
+
+/**
  * Audio Device Module API for controlling audio devices and settings.
  * iOS/macOS only - will throw on Android.
  */
 export class AudioDeviceModule {
+    /**
+     * Push (or clear with null) the native default audio-session configuration
+     * policy. When set, the native observer configures the session itself in
+     * willEnable/didDisable, removing the JS round trip from the default path.
+     * iOS/macOS only, a no-op on Android.
+     */
+    static setAutomaticAudioSessionConfiguration(config: AutomaticAudioSessionConfiguration | null): void {
+        if (Platform.OS === 'android' || !WebRTCModule) {
+            return;
+        }
+
+        WebRTCModule.audioDeviceModuleSetAutomaticAudioSessionConfiguration(config);
+    }
+
     /**
      * Start audio playback
      */

--- a/src/AudioDeviceModule.ts
+++ b/src/AudioDeviceModule.ts
@@ -26,13 +26,46 @@ export const AudioEngineAvailability = {
 } as const;
 
 /**
+ * Accepted values mirror the native observer's friendly-name maps. Unknown
+ * values never reach the session: categories fall back to playAndRecord and
+ * modes to default, and the literal unions below reject them at compile time.
+ */
+export type AutomaticAppleAudioCategory =
+  | 'ambient'
+  | 'soloAmbient'
+  | 'playback'
+  | 'record'
+  | 'playAndRecord'
+  | 'multiRoute';
+
+export type AutomaticAppleAudioMode =
+  | 'default'
+  | 'voiceChat'
+  | 'videoChat'
+  | 'gameChat'
+  | 'videoRecording'
+  | 'measurement'
+  | 'moviePlayback'
+  | 'spokenAudio'
+  | 'voicePrompt';
+
+export type AutomaticAppleAudioCategoryOption =
+  | 'mixWithOthers'
+  | 'duckOthers'
+  | 'allowBluetooth'
+  | 'allowBluetoothA2DP'
+  | 'allowAirPlay'
+  | 'defaultToSpeaker'
+  | 'interruptSpokenAudioAndMixWithOthers';
+
+/**
  * Apple audio session configuration for a single engine state. Matches the
  * AppleAudioConfiguration shape used by AudioSession.setAppleAudioConfiguration.
  */
 export interface AutomaticAppleAudioConfiguration {
-  audioCategory?: string;
-  audioMode?: string;
-  audioCategoryOptions?: string[];
+  audioCategory?: AutomaticAppleAudioCategory;
+  audioMode?: AutomaticAppleAudioMode;
+  audioCategoryOptions?: AutomaticAppleAudioCategoryOption[];
 }
 
 /**
@@ -57,10 +90,11 @@ export class AudioDeviceModule {
      * Push (or clear with null) the native default audio-session configuration
      * policy. When set, the native observer configures the session itself in
      * willEnable/didDisable, removing the JS round trip from the default path.
-     * iOS/macOS only, a no-op on Android.
+     * iOS only (including tvOS), a no-op elsewhere. The macOS build excludes
+     * the audio device module natives, so this must not reach the bridge there.
      */
     static setAutomaticAudioSessionConfiguration(config: AutomaticAudioSessionConfiguration | null): void {
-        if (Platform.OS === 'android' || !WebRTCModule) {
+        if (Platform.OS !== 'ios' || !WebRTCModule) {
             return;
         }
 

--- a/src/AudioDeviceModule.ts
+++ b/src/AudioDeviceModule.ts
@@ -92,6 +92,12 @@ export class AudioDeviceModule {
      * willEnable/didDisable, removing the JS round trip from the default path.
      * iOS only (including tvOS), a no-op elsewhere. The macOS build excludes
      * the audio device module natives, so this must not reach the bridge there.
+     *
+     * Requires registerGlobals() to have run first, which reconciles the native
+     * handler flags that decide precedence. Handler precedence is per hook:
+     * while a policy is set, custom willEnable/didDisable handlers must be
+     * registered or cleared as a pair, otherwise one regime can activate the
+     * session while the other never releases it.
      */
     static setAutomaticAudioSessionConfiguration(config: AutomaticAudioSessionConfiguration | null): void {
         if (Platform.OS !== 'ios' || !WebRTCModule) {

--- a/src/AudioDeviceModule.ts
+++ b/src/AudioDeviceModule.ts
@@ -71,9 +71,10 @@ export interface AutomaticAppleAudioConfiguration {
 /**
  * Native default audio-session policy. When set, the native observer configures
  * the AVAudioSession in willEnable/didDisable without a JS round trip.
- * `recording` is applied while recording is enabled, `playout` while only
- * playout is enabled, and the session is deactivated on full stop when
- * `deactivateOnStop` is true.
+ * - `recording` is applied while recording is enabled,
+ * - `playout` is applied while only playout is enabled,
+ * - `deactivateOnStop` determines whether the session is deactivated when
+ *   neither recording nor playout is enabled.
  */
 export interface AutomaticAudioSessionConfiguration {
   recording: AutomaticAppleAudioConfiguration;
@@ -93,11 +94,16 @@ export class AudioDeviceModule {
      * iOS only (including tvOS), a no-op elsewhere. The macOS build excludes
      * the audio device module natives, so this must not reach the bridge there.
      *
-     * Requires registerGlobals() to have run first, which reconciles the native
-     * handler flags that decide precedence. Handler precedence is per hook:
+     * Handler precedence is per hook:
      * while a policy is set, custom willEnable/didDisable handlers must be
      * registered or cleared as a pair, otherwise one regime can activate the
      * session while the other never releases it.
+     *
+     * Clearing a `deactivateOnStop: false` policy while the engine is already
+     * stopped (playout and recording both disabled) keeps the session activation
+     * held until the next engine cycle, because no callback fires in between.
+     * For an immediate release, stop under `deactivateOnStop: true` before
+     * clearing.
      */
     static setAutomaticAudioSessionConfiguration(config: AutomaticAudioSessionConfiguration | null): void {
         if (Platform.OS !== 'ios' || !WebRTCModule) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,16 @@ if (WebRTCModule === null) {
     }`);
 }
 
-import { AudioDeviceModule, AudioEngineMuteMode, AudioEngineAvailability } from './AudioDeviceModule';
+import {
+    AudioDeviceModule,
+    AudioEngineMuteMode,
+    AudioEngineAvailability,
+    type AutomaticAudioSessionConfiguration,
+    type AutomaticAppleAudioConfiguration,
+    type AutomaticAppleAudioCategory,
+    type AutomaticAppleAudioMode,
+    type AutomaticAppleAudioCategoryOption,
+} from './AudioDeviceModule';
 import { audioDeviceModuleEvents } from './AudioDeviceModuleEvents';
 import { setupNativeEvents } from './EventEmitter';
 import Logger from './Logger';
@@ -87,6 +96,11 @@ export {
     AudioDeviceModule,
     AudioEngineMuteMode,
     AudioEngineAvailability,
+    type AutomaticAudioSessionConfiguration,
+    type AutomaticAppleAudioConfiguration,
+    type AutomaticAppleAudioCategory,
+    type AutomaticAppleAudioMode,
+    type AutomaticAppleAudioCategoryOption,
     audioDeviceModuleEvents,
 };
 


### PR DESCRIPTION
## Summary

Adds an iOS-only API that pushes the default audio-session policy to native once. When no custom JS handlers are registered, `willEnableEngine` and `didDisableEngine` now configure `AVAudioSession` on the native worker thread. This removes the JS round trip from the default path and the circular-wait risk described in #89.

Custom JS handlers still take precedence and keep the bounded timeout. Native activation tracking handles normal stop, interruptions, and external deactivation. Switching between native and custom management during an active call remains unsupported. Switch while disconnected.

## Testing

- Built for iOS device and simulator with Xcode 26.6 and WebRTC-SDK 144.7559.10
- Smoke tested on device with CallKit and RNCallKeep through connect, mic publish, mute, and disconnect
- Observed no freeze, bridge-wait timeout, or native configuration failure
- Confirmed the audio session returned inactive after teardown

Current iOS CI failure is unrelated to this change. The React Native 0.71 example fails while compiling Yoga after `macos-latest` moved to macOS 26, before the native code from this PR is compiled.

## Before undrafting

- [ ] Add a regression test for the #89 circular-wait shape
- [ ] Repeat the device smoke test with the final decision logs

Companion PR: livekit/client-sdk-react-native#434