### PR TITLE
release: 144.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "144.1.2",
+  "version": "144.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@livekit/react-native-webrtc",
-      "version": "144.1.2",
+      "version": "144.2.0",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/react-native-webrtc",
-  "version": "144.1.2",
+  "version": "144.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/livekit/react-native-webrtc.git"


### PR DESCRIPTION
2596ab0 ios: move to the LiveKitWebRTC pod (144.7559.15) (#103)  ( Hiroshi Horie 2026-09-11 23:22:05 +0800)
faa1ff2 android: update libwebrtc to 144.7559.14 and move to prefixed artifact (#102)  ( davidliu 2026-09-12 00:22:05 +0900)